### PR TITLE
Popup to timeline

### DIFF
--- a/client/src/pages/Home/Home.jsx
+++ b/client/src/pages/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { getSlideshowImages, getTimelineDates } from './functions';
 import './Home.scss';
@@ -15,6 +15,7 @@ import MainFroshLogo from '../../assets/logo/frosh-main-logo.svg';
 import 'react-slideshow-image/dist/styles.css';
 import { Slide } from 'react-slideshow-image';
 import { ScheduleComponent } from '../../components/schedule/ScheduleHome/ScheduleHome';
+import { PopupModal } from '../../components/popup/PopupModal';
 
 const PageHome = () => {
   return (
@@ -86,10 +87,42 @@ const HomePageSlideshow = () => {
 };
 
 const HomePageTimeline = () => {
+  const [showPopUp, setShowPopUp] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState({});
   return (
     <div className="home-page-timeline">
       <h2 className="home-page-section-header">Timeline</h2>
-      <Timeline dates={getTimelineDates()} />
+      <Timeline
+        dates={getTimelineDates()}
+        onClick={(date) => {
+          setShowPopUp(true);
+          setSelectedEvent(date);
+        }}
+      />
+      <PopupModal
+        trigger={showPopUp}
+        setTrigger={setShowPopUp}
+        blurBackground={false}
+        exitIcon={true}
+      >
+        <div className="home-page-timeline-popup-container">
+          <h1>{selectedEvent.name}</h1>
+          <p>{selectedEvent.description}</p>
+          <div className="home-page-timeline-popup-button">
+            {selectedEvent.link !== undefined ? (
+              <a href={selectedEvent.link} target="_blank" className="no-link-style" rel="noreferrer">
+                <Button
+                  label={selectedEvent.linkLabel}
+                  isSecondary
+                  style={{ margin: 0, float: 'right' }}
+                ></Button>
+              </a>
+            ) : (
+              <></>
+            )}
+          </div>
+        </div>
+      </PopupModal>
     </div>
   );
 };

--- a/client/src/pages/Home/Home.jsx
+++ b/client/src/pages/Home/Home.jsx
@@ -108,19 +108,25 @@ const HomePageTimeline = () => {
         <div className="home-page-timeline-popup-container">
           <h1>{selectedEvent.name}</h1>
           <p>{selectedEvent.description}</p>
-          <div className="home-page-timeline-popup-button">
-            {selectedEvent.link !== undefined ? (
-              <a href={selectedEvent.link} target="_blank" className="no-link-style" rel="noreferrer">
+
+          {selectedEvent.link !== undefined ? (
+            <div className="home-page-timeline-popup-button">
+              <a
+                href={selectedEvent.link}
+                target="_blank"
+                className="no-link-style"
+                rel="noreferrer"
+              >
                 <Button
                   label={selectedEvent.linkLabel}
                   isSecondary
                   style={{ margin: 0, float: 'right' }}
                 ></Button>
               </a>
-            ) : (
-              <></>
-            )}
-          </div>
+            </div>
+          ) : (
+            <></>
+          )}
         </div>
       </PopupModal>
     </div>

--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -124,6 +124,28 @@
   }
 }
 
+.home-page-timeline-popup-container {
+  padding: 0px 50px;
+  color: var(--white);
+  h1 {
+    margin-bottom: 10px;
+    font-size: 34px;
+  }
+  p {
+    font-size: 18px;
+  }
+  .home-page-timeline-popup-button {
+    margin-top: 25px;
+  }
+  @include devices(tablet) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+}
+
 .home-page-schedule {
   background-color: var(--purple);
   padding-bottom: 30px;

--- a/client/src/pages/Home/functions.jsx
+++ b/client/src/pages/Home/functions.jsx
@@ -4,6 +4,8 @@ export function getTimelineDates() {
       date: new Date('2022-05-31T00:00:00'),
       name: 'Test 1234',
       description: 'Join other frosh and meetup! This is a really long description. ',
+      link: 'http://www.google.ca',
+      linkLabel: 'Click me!',
     },
     {
       date: new Date('2022-06-02T00:00:00'),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50821962/177432332-842241d2-d047-46ee-8cee-7954ca2b03ce.png)
![image](https://user-images.githubusercontent.com/50821962/177432347-137c18d3-3b45-408f-a55d-e41330ca2528.png)

Also added link, and link label attributes
This is because the timeline is usually used for summer meetups, and sometimes they have signup links to a Google form 