### PR TITLE
Form validation attribute

### DIFF
--- a/client/src/components/input/TextInput/TextInput.jsx
+++ b/client/src/components/input/TextInput/TextInput.jsx
@@ -21,6 +21,8 @@ const TextInput = ({
   inputTitle,
   isPhoneNumber,
   isInstagram,
+  isUtorID,
+  maxLength,
 }) => {
   useEffect(() => {
     if (localStorageKey !== undefined) {
@@ -69,11 +71,29 @@ const TextInput = ({
       let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
       if (match) {
         value = '(' + match[1] + ') ' + match[2] + '-' + match[3];
+      } else {
+        if (value.length >= 10) {
+          value = value.substring(0, 10);
+          value = value.replace(/\D/g, '');
+          let cleaned = ('' + value).replace(/\D/g, '');
+          let match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
+          if (match) {
+            value = '(' + match[1] + ') ' + match[2] + '-' + match[3];
+          }
+        }
       }
     }
     if (isInstagram) {
       if (value !== '' && !value.includes('@')) {
         value = '@' + value;
+      }
+    }
+    if (isUtorID) {
+      value = value.replace(' ', '').toLowerCase();
+    }
+    if (maxLength) {
+      if (value != undefined && maxLength < value.length) {
+        value = value.substring(0, value.length - 1);
       }
     }
 
@@ -170,6 +190,8 @@ TextInput.propTypes = {
   inputTitle: PropTypes.string,
   isPhoneNumber: PropTypes.bool,
   isInstagram: PropTypes.bool,
+  isUtorID: PropTypes.bool,
+  maxLength: PropTypes.number,
 };
 
 export { TextInput };

--- a/client/src/pages/Registration/RegistrationFields.jsx
+++ b/client/src/pages/Registration/RegistrationFields.jsx
@@ -7,6 +7,7 @@
 // className: the class name applied around the child form input component
 // noEdit: if set, this field CANNOT be modified AFTER the frosh registers
 //         Note: noEdit does not work for checkboxes
+// validation(value): if set, return true for a valid input, return a string as the error message. The check will fail if a string is returned.
 export const fields = {
   General: {
     name: {
@@ -16,6 +17,7 @@ export const fields = {
       label: 'Legal Name',
       isRequiredInput: true,
       errorMessage: 'Please enter your legal name',
+      localStorageKey: 'registration-legal-name',
     },
     pronoun: {
       type: 'dropdown',
@@ -49,17 +51,37 @@ export const fields = {
       isRequiredInput: true,
       errorMessage: 'Please enter a valid date',
       className: 'half-width-input',
+      validation: (value) => {
+        if (
+          value !== undefined &&
+          value.split('-')[0] !== undefined &&
+          parseInt(value.split('-')[0]) >= 1920 &&
+          parseInt(value.split('-')[0]) <= 2020
+        ) {
+          return true;
+        } else {
+          return 'Please ensure your birthday is between 1920 and 2020';
+        }
+      },
     },
     utorid: {
       type: 'text',
       inputType: 'text',
       label: 'UtorID',
-      placeholder: 'doejohn123',
+      placeholder: 'doejohn1',
       hasRestrictedInput: true,
       isRequiredInput: true,
       errorMessage: 'Please enter your UtorID',
       localStorageKey: 'registration-utorid',
       className: 'half-width-input',
+      validation: (value) => {
+        if (value !== undefined && value.toString().length === 8) {
+          return true;
+        } else {
+          return 'Your UtorID should be 8 characters long';
+        }
+      },
+      isUtorID: true,
     },
     discipline: {
       type: 'dropdown',
@@ -98,6 +120,7 @@ export const fields = {
       localStorageKey: 'registration-phoneNumberAreaCode',
       className: 'small-width-input',
       inputTitle: 'Area Code',
+      maxLength: 3,
     },
     phoneNumber: {
       type: 'text',
@@ -156,6 +179,7 @@ export const fields = {
       localStorageKey: 'registration-emergencyContactNumberAreaCode',
       className: 'small-width-input',
       inputTitle: 'Area Code',
+      maxLength: 3,
     },
     emergencyContactNumber: {
       type: 'text',

--- a/client/src/pages/Registration/RegistrationForm.jsx
+++ b/client/src/pages/Registration/RegistrationForm.jsx
@@ -63,20 +63,35 @@ const PageRegistrationForm = ({ editFieldsPage, initialValues, onEditSubmit }) =
     const formFieldsCopy = { ...formFields };
     for (let step of steps) {
       for (let key of Object.keys(formFields[step])) {
+        let localValidated = true;
         if (formFields[step][key].type === 'label') {
           continue;
+        }
+        if (formFields[step][key].validation !== undefined) {
+          const validateResult = formFields[step][key].validation(froshObject[key]);
+          if (validateResult !== true) {
+            formFieldsCopy[step][key].errorFeedback = validateResult;
+            localValidated = false;
+            if (validated === true) {
+              setSelectedTab(steps.indexOf(step, 0));
+              setSelectedTabGo(!selectedTabGo);
+              validated = false;
+            }
+          }
         }
         if (
           (froshObject[key] === undefined || froshObject[key] === '') &&
           formFields[step][key].isRequiredInput === true
         ) {
           formFieldsCopy[step][key].errorFeedback = formFields[step][key].errorMessage;
+          localValidated = false;
           if (validated === true) {
             setSelectedTab(steps.indexOf(step, 0));
             setSelectedTabGo(!selectedTabGo);
             validated = false;
           }
-        } else {
+        }
+        if (localValidated !== false) {
           formFieldsCopy[step][key].errorFeedback = '';
         }
       }
@@ -116,6 +131,8 @@ const PageRegistrationForm = ({ editFieldsPage, initialValues, onEditSubmit }) =
                   }}
                   isPhoneNumber={field.isPhoneNumber}
                   isInstagram={field.isInstagram}
+                  isUtorID={field.isUtorID}
+                  maxLength={field.maxLength}
                   isDisabled={
                     editFieldsPage === true && field.isDisabled !== true
                       ? field.noEdit


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50821962/177444544-3f89c921-b708-47e9-a2ae-a9959004ed5a.png)
This also fixes https://github.com/UofT-Frosh-Orientation/orientation-website/issues/245
Also made the example placeholder UtorID follow the 8 character limit
Example:
```js
     validation: (value) => {
        if (
          value !== undefined &&
          value.split('-')[0] !== undefined &&
          parseInt(value.split('-')[0]) >= 1920 &&
          parseInt(value.split('-')[0]) <= 2020
        ) {
          return true;
        } else {
          return 'Please ensure your birthday is between 1920 and 2020';
        }
      },
```

Added `maxLength` and `isUtorID` props to `Textinput`
Fixed `isPhoneNumber` from going over the limit