### PR TITLE
only displaying Havenger Scunt for evening events on wednesday

### DIFF
--- a/client/src/assets/schedule/data.jsx
+++ b/client/src/assets/schedule/data.jsx
@@ -127,9 +127,9 @@
       Color: 'gray',
     },
     {
-      'Event Name': 'Havenger Scunt / Nitelife',
+      'Event Name': 'Havenger Scunt',
       'Event Description':
-        'Havenger Scunt: The longest items list you’ve ever seen. Join us for a full fledged scavenger hunt all over the city of Toronto!\nNitelife: You thought F!rosh week stopped at 6:00 pm? Think again we have activities every day of F!rosh Week for you to engage in!',
+        'The longest items list you’ve ever seen. Join us for a full fledged scavenger hunt all over the city of Toronto!',
       'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',

--- a/client/src/pages/Profile/functions.jsx
+++ b/client/src/pages/Profile/functions.jsx
@@ -152,9 +152,9 @@ export function getFroshScheduleData() {
           Color: 'gray',
         },
         {
-          name: 'Havenger Scunt / Nitelife',
+          name: 'Havenger Scunt',
           description:
-            'Havenger Scunt: The longest items list you’ve ever seen. Join us for a full fledged scavenger hunt all over the city of Toronto!\nNitelife: You thought F!rosh week stopped at 6:00 pm? Think again we have activities every day of F!rosh Week for you to engage in!',
+            'The longest items list you’ve ever seen. Join us for a full fledged scavenger hunt all over the city of Toronto!',
           time: '6:00 PM - Late',
           Color: 'dark-purple',
         },


### PR DESCRIPTION
removed nitelife from wednesday evening events (on home page and profile page schedule)
![image](https://user-images.githubusercontent.com/86009011/179340260-8c4fa4db-aedd-470c-ad4e-d905686d0fc4.png)
