### PR TITLE
504 store title of announcement in backend

### DIFF
--- a/server/src/models/UserModel.js
+++ b/server/src/models/UserModel.js
@@ -83,6 +83,9 @@ const UserSchema = new mongoose.Schema(
           announcementID: {
             type: String,
           },
+          announcementName: {
+            type: String,
+          },
         },
       ],
       default: [],

--- a/server/src/services/AnnouncementServices.js
+++ b/server/src/services/AnnouncementServices.js
@@ -31,7 +31,7 @@ const AnnouncementServices = {
               return value.id != announcement.id;
             })
           ) {
-            listOfCompleted.push(announcement.id);
+            listOfCompleted.push({ _id: announcement.id, announcementName: announcement.name });
           } else {
             listOfCompleted.splice(removeIndex, 1);
           }


### PR DESCRIPTION
Resolves #504 

To test complete an announcement as a user. In the database the name and ID of the announcement should be stores in the user document.