### PR TITLE
About Us Page Optimizations

### DIFF
--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -18,12 +18,14 @@ import InstagramIcon from '../../assets/social/instagram-brands.svg';
 import MailIcon from '../../assets/social/envelope-solid.svg';
 import { instagramAccounts } from '../../util/instagramAccounts';
 
+import { Button } from '../../components/button/Button/Button';
+
 const PageAbout = () => {
   return (
     <>
       <div className="aboutus-page-components">
         <AboutUsSection />
-        <AboutUsTeamsTab />
+        <AboutUsTeamsTabWrapper />
         <div className="about-attribution-container">
           <p className="about-attribution-message">
             Thank you to{' '}
@@ -284,18 +286,22 @@ const tabs = [
   {
     title: 'Exec Team',
     component: <AboutUsExecTeam />,
+    active: true,
   },
   {
     title: 'Tech Team',
     component: <AboutUsTechTeam />,
+    active: true,
   },
   {
     title: 'Subcoms',
     component: <AboutUsSubcom />,
+    active: true,
   },
   {
     title: 'Head Leedurs',
     component: <AboutUsHL />,
+    active: true,
   },
 ];
 
@@ -311,51 +317,69 @@ const AboutUsTeamsTab = () => {
       <div className="aboutus-teams-all-tabs">
         <div className="aboutus-teams-all-tabs-scroll">
           {tabs.map((tab) => {
-            tabsCounter++;
-            //console.log(tabsCounter);
-            return (
-              <div key={tab.title} className="aboutus-teams-tabs">
-                <div
-                  className="aboutus-teams-tabs-container"
-                  onClick={() => {
-                    setCurrentTab(tab.title);
-                  }}
-                >
-                  {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
+            if (tab.active) {
+              tabsCounter++;
+              //console.log(tabsCounter);
+              return (
+                <div key={tab.title} className="aboutus-teams-tabs">
                   <div
-                    style={{ display: 'flex', flexDirection: 'column', justifyContent: 'start' }}
+                    className="aboutus-teams-tabs-container"
+                    onClick={() => {
+                      setCurrentTab(tab.title);
+                    }}
                   >
-                    <h1
-                      className={
-                        currentTab === tab.title
-                          ? 'aboutus-teams-tabs-title-selected'
-                          : 'aboutus-teams-tabs-title'
-                      }
-                    >
-                      {tab.title}
-                    </h1>
+                    {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
                     <div
-                      className={`aboutus-yellow-bubble ${
-                        currentTab === tab.title
-                          ? 'aboutus-yellow-bubble-show'
-                          : 'aboutus-yellow-bubble-noshow'
-                      }`}
-                    ></div>
+                      style={{ display: 'flex', flexDirection: 'column', justifyContent: 'start' }}
+                    >
+                      <h1
+                        className={
+                          currentTab === tab.title
+                            ? 'aboutus-teams-tabs-title-selected'
+                            : 'aboutus-teams-tabs-title'
+                        }
+                      >
+                        {tab.title}
+                      </h1>
+                      <div
+                        className={`aboutus-yellow-bubble ${
+                          currentTab === tab.title
+                            ? 'aboutus-yellow-bubble-show'
+                            : 'aboutus-yellow-bubble-noshow'
+                        }`}
+                      ></div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
+              );
+            } else {
+              return; // tab is not meant to be active
+            }
           })}
         </div>
       </div>
 
       <div className="aboutus-tabs-component">
         {tabs.map((tab) => {
-          if (currentTab === tab.title) {
+          if (currentTab === tab.title && tab.active) {
             return tab.component;
           }
         })}
       </div>
+    </>
+  );
+};
+
+const AboutUsTeamsTabWrapper = () => {
+  const [showAboutUs, setShowAboutUs] = useState(true);
+
+  if (!showAboutUs) tabs.map((tab) => (tab.active = false));
+  else tabs.map((tab) => (tab.active = true));
+
+  return (
+    <>
+      <Button label="Toggle Show Team" onClick={() => setShowAboutUs(!showAboutUs)} />
+      <AboutUsTeamsTab />
     </>
   );
 };

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -305,7 +305,7 @@ const tabs = [
     title: 'Head Leedurs',
     component: <AboutUsHL />,
     active: true,
-    wantToLoad: true,
+    wantToLoad: false,
   },
 ];
 
@@ -383,9 +383,13 @@ const AboutUsTeamsTab = () => {
 };
 
 const AboutUsTeamsTabWrapper = () => {
-  const showAboutUs = true;
+  let showAboutUs = true;
 
   tabs.map((tab) => (tab.active = showAboutUs ? tab.wantToLoad : false));
+
+  // set showAboutUs in case every single tab is false
+
+  showAboutUs = !tabs.every((tab, i, a) => !tab.wantToLoad);
 
   return (
     <>

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -299,7 +299,7 @@ const tabs = [
     title: 'Subcoms',
     component: <AboutUsSubcom />,
     active: true,
-    wantToLoad: true,
+    wantToLoad: false,
   },
   {
     title: 'Head Leedurs',
@@ -383,7 +383,7 @@ const AboutUsTeamsTab = () => {
 };
 
 const AboutUsTeamsTabWrapper = () => {
-  let showAboutUs = true;
+  let showAboutUs = false;
 
   tabs.map((tab) => (tab.active = showAboutUs ? tab.wantToLoad : false));
 

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -312,62 +312,77 @@ const AboutUsTeamsTab = () => {
   let numTabs = tabs.length;
   let tabComponent;
 
-  return (
-    <>
-      <div className="aboutus-teams-all-tabs">
-        <div className="aboutus-teams-all-tabs-scroll">
-          {tabs.map((tab) => {
-            if (tab.active) {
-              tabsCounter++;
-              //console.log(tabsCounter);
-              return (
-                <div key={tab.title} className="aboutus-teams-tabs">
-                  <div
-                    className="aboutus-teams-tabs-container"
-                    onClick={() => {
-                      setCurrentTab(tab.title);
-                    }}
-                  >
-                    {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
+  if (tabs.every((value, index, array) => value.active))
+    return (
+      <>
+        <div className="aboutus-teams-all-tabs">
+          <div className="aboutus-teams-all-tabs-scroll">
+            {tabs.map((tab) => {
+              if (tab.active) {
+                tabsCounter++;
+                //console.log(tabsCounter);
+                return (
+                  <div key={tab.title} className="aboutus-teams-tabs">
                     <div
-                      style={{ display: 'flex', flexDirection: 'column', justifyContent: 'start' }}
+                      className="aboutus-teams-tabs-container"
+                      onClick={() => {
+                        setCurrentTab(tab.title);
+                      }}
                     >
-                      <h1
-                        className={
-                          currentTab === tab.title
-                            ? 'aboutus-teams-tabs-title-selected'
-                            : 'aboutus-teams-tabs-title'
-                        }
-                      >
-                        {tab.title}
-                      </h1>
+                      {tabsCounter > 1 ? (
+                        <div className="aboutus-short-vertical-line"></div>
+                      ) : (
+                        <></>
+                      )}
                       <div
-                        className={`aboutus-yellow-bubble ${
-                          currentTab === tab.title
-                            ? 'aboutus-yellow-bubble-show'
-                            : 'aboutus-yellow-bubble-noshow'
-                        }`}
-                      ></div>
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          justifyContent: 'start',
+                        }}
+                      >
+                        <h1
+                          className={
+                            currentTab === tab.title
+                              ? 'aboutus-teams-tabs-title-selected'
+                              : 'aboutus-teams-tabs-title'
+                          }
+                        >
+                          {tab.title}
+                        </h1>
+                        <div
+                          className={`aboutus-yellow-bubble ${
+                            currentTab === tab.title
+                              ? 'aboutus-yellow-bubble-show'
+                              : 'aboutus-yellow-bubble-noshow'
+                          }`}
+                        ></div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            } else {
-              return; // tab is not meant to be active
+                );
+              } else {
+                return;
+              }
+            })}
+          </div>
+        </div>
+
+        <div className="aboutus-tabs-component">
+          {tabs.map((tab) => {
+            if (currentTab === tab.title && tab.active) {
+              return tab.component;
             }
           })}
         </div>
-      </div>
-
-      <div className="aboutus-tabs-component">
-        {tabs.map((tab) => {
-          if (currentTab === tab.title && tab.active) {
-            return tab.component;
-          }
-        })}
-      </div>
-    </>
-  );
+      </>
+    );
+  else
+    return (
+      <>
+        <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>
+      </>
+    );
 };
 
 const AboutUsTeamsTabWrapper = () => {
@@ -378,7 +393,6 @@ const AboutUsTeamsTabWrapper = () => {
 
   return (
     <>
-      <Button label="Toggle Show Team" onClick={() => setShowAboutUs(!showAboutUs)} />
       <AboutUsTeamsTab />
     </>
   );

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -18,7 +18,7 @@ import InstagramIcon from '../../assets/social/instagram-brands.svg';
 import MailIcon from '../../assets/social/envelope-solid.svg';
 import { instagramAccounts } from '../../util/instagramAccounts';
 
-import { Button } from '../../components/button/Button/Button';
+import PropTypes from 'prop-types';
 
 const PageAbout = () => {
   return (
@@ -287,113 +287,113 @@ const tabs = [
     title: 'Exec Team',
     component: <AboutUsExecTeam />,
     active: true,
+    wantToLoad: false,
   },
   {
     title: 'Tech Team',
     component: <AboutUsTechTeam />,
     active: true,
+    wantToLoad: false,
   },
   {
     title: 'Subcoms',
     component: <AboutUsSubcom />,
     active: true,
+    wantToLoad: true,
   },
   {
     title: 'Head Leedurs',
     component: <AboutUsHL />,
     active: true,
+    wantToLoad: true,
   },
 ];
 
 const AboutUsTeamsTab = () => {
-  const [currentTab, setCurrentTab] = useState('Exec Team');
+  const wantedTabs = tabs.filter((tab) => tab.wantToLoad);
+  console.log(wantedTabs);
+  const [currentTab, setCurrentTab] = useState(
+    wantedTabs.length > 0 ? wantedTabs.at(0).title : 'Exec Team',
+  );
 
   let tabsCounter = 0;
   let numTabs = tabs.length;
   let tabComponent;
 
-  if (tabs.every((value, index, array) => value.active))
-    return (
-      <>
-        <div className="aboutus-teams-all-tabs">
-          <div className="aboutus-teams-all-tabs-scroll">
-            {tabs.map((tab) => {
-              if (tab.active) {
-                tabsCounter++;
-                //console.log(tabsCounter);
-                return (
-                  <div key={tab.title} className="aboutus-teams-tabs">
+  return (
+    <>
+      <div className="aboutus-teams-all-tabs">
+        <div className="aboutus-teams-all-tabs-scroll">
+          {tabs.map((tab) => {
+            if (tab.active) {
+              tabsCounter++;
+              //console.log(tabsCounter);
+              return (
+                <div key={tab.title} className="aboutus-teams-tabs">
+                  <div
+                    className="aboutus-teams-tabs-container"
+                    onClick={() => {
+                      setCurrentTab(tab.title);
+                    }}
+                  >
+                    {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
                     <div
-                      className="aboutus-teams-tabs-container"
-                      onClick={() => {
-                        setCurrentTab(tab.title);
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'start',
                       }}
                     >
-                      {tabsCounter > 1 ? (
-                        <div className="aboutus-short-vertical-line"></div>
-                      ) : (
-                        <></>
-                      )}
-                      <div
-                        style={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          justifyContent: 'start',
-                        }}
+                      <h1
+                        className={
+                          currentTab === tab.title
+                            ? 'aboutus-teams-tabs-title-selected'
+                            : 'aboutus-teams-tabs-title'
+                        }
                       >
-                        <h1
-                          className={
-                            currentTab === tab.title
-                              ? 'aboutus-teams-tabs-title-selected'
-                              : 'aboutus-teams-tabs-title'
-                          }
-                        >
-                          {tab.title}
-                        </h1>
-                        <div
-                          className={`aboutus-yellow-bubble ${
-                            currentTab === tab.title
-                              ? 'aboutus-yellow-bubble-show'
-                              : 'aboutus-yellow-bubble-noshow'
-                          }`}
-                        ></div>
-                      </div>
+                        {tab.title}
+                      </h1>
+                      <div
+                        className={`aboutus-yellow-bubble ${
+                          currentTab === tab.title
+                            ? 'aboutus-yellow-bubble-show'
+                            : 'aboutus-yellow-bubble-noshow'
+                        }`}
+                      ></div>
                     </div>
                   </div>
-                );
-              } else {
-                return;
-              }
-            })}
-          </div>
-        </div>
-
-        <div className="aboutus-tabs-component">
-          {tabs.map((tab) => {
-            if (currentTab === tab.title && tab.active) {
-              return tab.component;
+                </div>
+              );
+            } else {
+              return;
             }
           })}
         </div>
-      </>
-    );
-  else
-    return (
-      <>
-        <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>
-      </>
-    );
+      </div>
+
+      <div className="aboutus-tabs-component">
+        {tabs.map((tab) => {
+          if (currentTab === tab.title && tab.active) {
+            return tab.component;
+          }
+        })}
+      </div>
+    </>
+  );
 };
 
 const AboutUsTeamsTabWrapper = () => {
-  const [showAboutUs, setShowAboutUs] = useState(true);
+  const showAboutUs = true;
 
-  if (!showAboutUs) tabs.map((tab) => (tab.active = false));
-  else tabs.map((tab) => (tab.active = true));
+  tabs.map((tab) => (tab.active = showAboutUs ? tab.wantToLoad : false));
 
   return (
     <>
-      <AboutUsTeamsTab />
+      {showAboutUs ? (
+        <AboutUsTeamsTab />
+      ) : (
+        <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>
+      )}
     </>
   );
 };

--- a/client/src/pages/About/About.scss
+++ b/client/src/pages/About/About.scss
@@ -18,6 +18,19 @@
   background-color: purple;
 }
 
+.about-introduction-title {
+  text-align: left;
+  font-size: 60px;
+  color: var(--white);
+  margin-top: 50px;
+  text-align: center;
+
+  @include devices(tablet) {
+    margin-top: 25px;
+    font-size: 40px;
+  }
+}
+
 // ABOUT US SECTION
 
 .aboutus-subsubcontainer {

--- a/client/src/pages/About/ExecProfile/ExecProfile.jsx
+++ b/client/src/pages/About/ExecProfile/ExecProfile.jsx
@@ -9,7 +9,7 @@ import wave from '../../../assets/about/wave-about.svg';
 import { useState, useEffect } from 'react';
 
 // Set 5s to read the post before closing automatically, configure as needed
-const EXEC_TIMEOUT = 5000;
+const EXEC_TIMEOUT = 25000;
 
 const ExecProfile = ({
   image,

--- a/client/src/pages/About/ExecProfile/ExecProfile.jsx
+++ b/client/src/pages/About/ExecProfile/ExecProfile.jsx
@@ -6,7 +6,10 @@ import 'react-lazy-load-image-component/src/effects/blur.css';
 import './ExecProfile.scss';
 
 import wave from '../../../assets/about/wave-about.svg';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+
+// Set 5s to read the post before closing automatically, configure as needed
+const EXEC_TIMEOUT = 5000;
 
 const ExecProfile = ({
   image,
@@ -25,6 +28,13 @@ const ExecProfile = ({
 }) => {
   // initialize to false, don't show description
   const [showDescription, setShowDescription] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (showDescription) setShowDescription(!showDescription); // stop showing description
+    }, EXEC_TIMEOUT);
+    return () => clearTimeout(timer);
+  }, [showDescription]);
 
   return (
     <div


### PR DESCRIPTION
## **Contribution:**


### **Issue:**

Closes #601 

### **Accomplishments:**

- Created a timeout on the `ExecProfile` component with a constant `EXEC_TIMEOUT` to configure how long it takes before defaulting
- Created a wrapper for the `AboutUsTeamTabs` component that now has the state variable `showAboutUs` to display or not (functionality shown with a simple toggle button)

### **Visuals:** 

Just used a default button

## **Details:**

### **Expected Behavior:**

- Upon clicking on a profile it should revert back to the photo in 5 seconds
- On clicking the toggle it should toggle displaying the team alongside maintaining the current tab.

### **Testing Steps:**

Steps required to get expected behavior.

- start the front end (no docker needed)
- Go to About page and scroll down to see the components

### **Complications:**

- Just getting used to Hooks and attempting to set timeout accurately in React

### **Resources:**

Any additional resources used outside this in issue.

- [Help with react timers](https://felixgerschau.com/react-hooks-settimeout/) 
