### PR TITLE
679 fix frosh assignment

### DIFF
--- a/client/src/components/profile/leedur/PermissionDashboardLinks/ProfilePageLeaderPermissionDashboardLinks.jsx
+++ b/client/src/components/profile/leedur/PermissionDashboardLinks/ProfilePageLeaderPermissionDashboardLinks.jsx
@@ -36,6 +36,12 @@ export const ProfilePageLeaderPermissionDashboardLinks = () => {
           link: '/frosh-info-table',
           authScopes: [],
         },
+        {
+          label: 'Frosh Redistribution',
+          anyRegisterScope: false,
+          link: '/frosh-redistribution',
+          authScopes: ['admin:all'],
+        },
       ],
     },
     {

--- a/client/src/pages/FroshRedistribution/FroshRedistribution.jsx
+++ b/client/src/pages/FroshRedistribution/FroshRedistribution.jsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect, useContext } from 'react';
+import './FroshRedistribution.scss';
+import { useDispatch, useSelector } from 'react-redux';
+import { redistributeFrosh } from '../../state/frosh/saga';
+import { Button } from '../../components/button/Button/Button';
+
+
+
+
+
+const PageFroshRedistribution = () => {
+     const dispatch = useDispatch();
+
+    const submitForm = () => {
+        dispatch(redistributeFrosh({}));
+    };
+
+    return(
+         <Button
+             label="Redistribute Frosh"
+             onClick={async () => {
+                 submitForm();
+             }}
+         />
+    );
+};
+  
+export { PageFroshRedistribution };

--- a/client/src/pages/FroshRedistribution/FroshRedistribution.jsx
+++ b/client/src/pages/FroshRedistribution/FroshRedistribution.jsx
@@ -1,28 +1,40 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useEffect } from 'react';
 import './FroshRedistribution.scss';
 import { useDispatch, useSelector } from 'react-redux';
 import { redistributeFrosh } from '../../state/frosh/saga';
 import { Button } from '../../components/button/Button/Button';
-
-
-
-
-
+import { froshSelector } from '../../state/frosh/froshSlice';
 const PageFroshRedistribution = () => {
-     const dispatch = useDispatch();
+  const dispatch = useDispatch();
+  const { frosh, error } = useSelector(froshSelector);
+  const submitForm = () => {
+    dispatch(redistributeFrosh());
+  };
 
-    const submitForm = () => {
-        dispatch(redistributeFrosh({}));
-    };
+  useEffect(() => {
+    if (error) {
+      alert(error);
+    }
+    console.error(error);
+  }, [error]);
 
-    return(
-         <Button
-             label="Redistribute Frosh"
-             onClick={async () => {
-                 submitForm();
-             }}
-         />
-    );
+  return (
+    <>
+      <Button label="Redistribute Frosh" onClick={submitForm} />
+      {frosh?.map((frosh) =>
+        frosh.to ? (
+          <div key={frosh?.firstName}>
+            <h2>
+              Frosh: {frosh?.firstName} {frosh?.lastName} ({frosh?.email})
+            </h2>
+            <h2>Reassigned to: {frosh?.to}</h2>
+          </div>
+        ) : (
+          <></>
+        ),
+      )}
+    </>
+  );
 };
-  
+
 export { PageFroshRedistribution };

--- a/client/src/state/frosh/froshSlice.jsx
+++ b/client/src/state/frosh/froshSlice.jsx
@@ -24,10 +24,22 @@ const froshSlice = createSlice({
       state.loading = false;
       state.error = error;
     },
+    redistributeFroshStart: (state) => {
+      state.loading = true;
+      state.error = null;
+    },
+    redistributeFroshSuccess: (state) => {
+      state.loading = false;
+      state.error = null;
+    },
+    redistributeFroshFailure: (state, { payload: error }) => {
+      state.loading = false;
+      state.error = error;
+    },
   },
 });
 
-export const { getFroshStart, getFroshSuccess, getFroshFailure } = froshSlice.actions;
+export const { getFroshStart, getFroshSuccess, getFroshFailure, redistributeFroshStart, redistributeFroshSuccess, redistributeFroshFailure} = froshSlice.actions;
 
 export default froshSlice.reducer;
 

--- a/client/src/state/frosh/froshSlice.jsx
+++ b/client/src/state/frosh/froshSlice.jsx
@@ -28,9 +28,10 @@ const froshSlice = createSlice({
       state.loading = true;
       state.error = null;
     },
-    redistributeFroshSuccess: (state) => {
+    redistributeFroshSuccess: (state, { payload: reassignedFrosh }) => {
       state.loading = false;
       state.error = null;
+      state.frosh = reassignedFrosh;
     },
     redistributeFroshFailure: (state, { payload: error }) => {
       state.loading = false;
@@ -39,7 +40,14 @@ const froshSlice = createSlice({
   },
 });
 
-export const { getFroshStart, getFroshSuccess, getFroshFailure, redistributeFroshStart, redistributeFroshSuccess, redistributeFroshFailure} = froshSlice.actions;
+export const {
+  getFroshStart,
+  getFroshSuccess,
+  getFroshFailure,
+  redistributeFroshStart,
+  redistributeFroshSuccess,
+  redistributeFroshFailure,
+} = froshSlice.actions;
 
 export default froshSlice.reducer;
 

--- a/client/src/state/frosh/saga.jsx
+++ b/client/src/state/frosh/saga.jsx
@@ -1,7 +1,14 @@
 import { createAction } from '@reduxjs/toolkit';
 import useAxios from '../../hooks/useAxios';
 import { put, call, takeLeading } from 'redux-saga/effects';
-import { getFroshFailure, getFroshStart, getFroshSuccess, redistributeFroshFailure, redistributeFroshStart, redistributeFroshSuccess} from './froshSlice';
+import {
+  getFroshFailure,
+  getFroshStart,
+  getFroshSuccess,
+  redistributeFroshFailure,
+  redistributeFroshStart,
+  redistributeFroshSuccess,
+} from './froshSlice';
 
 export const getFrosh = createAction('getFroshSaga');
 
@@ -17,7 +24,6 @@ export function* getFroshSaga({ payload: { showAllUsers } }) {
   }
 }
 
-
 export const redistributeFrosh = createAction('redistributeFroshSaga');
 
 export function* redistributeFroshSaga() {
@@ -25,15 +31,14 @@ export function* redistributeFroshSaga() {
   try {
     yield put(redistributeFroshStart());
     const result = yield call(axios.post, '/frosh/redistribute');
-    yield put(redistributeFroshSuccess());
+    yield put(redistributeFroshSuccess(result?.data?.reassignedFrosh));
   } catch (e) {
     console.error(e);
     yield put(redistributeFroshFailure(e));
   }
 }
 
-
 export default function* froshSaga() {
   yield takeLeading(getFrosh.type, getFroshSaga);
-  yield takeLeading(getFrosh.type, redistributeFroshSaga);
+  yield takeLeading(redistributeFrosh.type, redistributeFroshSaga);
 }

--- a/client/src/state/frosh/saga.jsx
+++ b/client/src/state/frosh/saga.jsx
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 import useAxios from '../../hooks/useAxios';
 import { put, call, takeLeading } from 'redux-saga/effects';
-import { getFroshFailure, getFroshStart, getFroshSuccess } from './froshSlice';
+import { getFroshFailure, getFroshStart, getFroshSuccess, redistributeFroshFailure, redistributeFroshStart, redistributeFroshSuccess} from './froshSlice';
 
 export const getFrosh = createAction('getFroshSaga');
 
@@ -16,6 +16,24 @@ export function* getFroshSaga({ payload: { showAllUsers } }) {
     yield put(getFroshFailure(e));
   }
 }
+
+
+export const redistributeFrosh = createAction('redistributeFroshSaga');
+
+export function* redistributeFroshSaga() {
+  const { axios } = useAxios();
+  try {
+    yield put(redistributeFroshStart());
+    const result = yield call(axios.post, '/frosh/redistribute');
+    yield put(redistributeFroshSuccess());
+  } catch (e) {
+    console.error(e);
+    yield put(redistributeFroshFailure(e));
+  }
+}
+
+
 export default function* froshSaga() {
   yield takeLeading(getFrosh.type, getFroshSaga);
+  yield takeLeading(getFrosh.type, redistributeFroshSaga);
 }

--- a/client/src/util/pages.jsx
+++ b/client/src/util/pages.jsx
@@ -16,6 +16,7 @@ import { PageAccountsApproval } from '../pages/AccountsApproval/AccountsApproval
 import AuthorizedPage from './AuthorizedPage';
 import { PasswordReset } from '../pages/PasswordReset/PasswordReset';
 import { PageFroshInfoTable } from '../pages/FroshInfoTable/FroshInfoTable';
+import { PageFroshRedistribution } from '../pages/FroshRedistribution/FroshRedistribution';
 import { PageScopeRequest } from '../pages/ScopeRequest/ScopeRequest';
 // import { PageScuntJudgeForm } from '../pages/ScuntJudgeForm/ScuntJudgeForm';
 // import { PageScuntMissionsList } from '../pages/ScuntMissionsList/ScuntMissionsList';
@@ -238,6 +239,15 @@ export const pages = {
         </AuthorizedPage>
       ),
       path: '/frosh-info-table',
+    },
+    {
+      label: 'frosh-redistribution',
+      component: (
+        <AuthorizedPage leaderOnly>
+          <PageFroshRedistribution />
+        </AuthorizedPage>
+      ),
+      path: '/frosh-redistribution',
     },
   ],
   scunt: [

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -11,6 +11,12 @@ module.exports = {
   },
   parser: '@babel/eslint-parser',
   rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'comma-dangle': ['error', 'always-multiline'],
     'comma-spacing': ['error', { before: false, after: true }],
     'no-multiple-empty-lines': ['error'],

--- a/server/src/controllers/FroshController.js
+++ b/server/src/controllers/FroshController.js
@@ -131,12 +131,10 @@ const FroshController = {
     }
   },
 
-
   async reassignFrosh(req, res, next) {
     try {
-      if (!req.user?.froshDataFields?.approved?.length) {
-        return next(new Error('UNAUTHORIZED'));
-      }
+      if (!req.user?.froshDataFields?.approved?.length) return next(new Error('UNAUTHORIZED'));
+
       const filter = req.user?.froshDataFields?.approved.reduce(
         (prev, curr) => {
           prev[curr] = 1;
@@ -144,12 +142,12 @@ const FroshController = {
         },
         { _id: 1 },
       );
-      query = {isRegistered: true };
+      const query = { isRegistered: true };
       const frosh = await FroshServices.getFilteredFroshInfo(query, filter);
-      FroshServices.mapFroshUsers(frosh);
 
-      return res.status(200).send({frosh});
+      const reassignedFrosh = await FroshServices.mapFroshUsers(frosh);
 
+      return res.status(200).send({ reassignedFrosh });
     } catch (e) {
       req.log.fatal({
         msg: 'Unable to reassign requested frosh users',
@@ -160,10 +158,5 @@ const FroshController = {
     }
   },
 };
-
-
-
-
-
 
 module.exports = FroshController;

--- a/server/src/controllers/FroshController.js
+++ b/server/src/controllers/FroshController.js
@@ -134,33 +134,6 @@ const FroshController = {
 
   async reassignFrosh(req, res, next) {
     try {
-      
-      async function mapFroshUsers(frosh, index) {   
-        if(index >= frosh.length){
-          return;
-        }
-        if (frosh[index]['pronouns'] !== undefined && (frosh[index][pronouns].toString().includes('He/Him') || frosh[index][pronouns].toString().includes('She/Her')) ) {
-          const froshUser = frosh[index];
-          const { froshGroup, froshGroupIcon } = await FroshServices.getNewFroshGroup(
-            froshUser.discipline,
-            froshUser.pronouns,
-          );
-          
-          if(froshGroup == froshUser.froshGroup){
-            //Redo this index
-            await mapFroshUsers(frosh, index);
-          }
-          else{
-            //Change frosh group of this user
-            await FroshServices.updateFroshInfo(froshUser.id, {froshGroup: froshGroup, froshGroupIcon: froshGroupIcon});
-            await mapFroshUsers(frosh, index + 1);
-          }
-        }
-        else{
-          await mapFroshUsers(frosh, index + 1);
-        }
-      }
-      
       if (!req.user?.froshDataFields?.approved?.length) {
         return next(new Error('UNAUTHORIZED'));
       }
@@ -173,9 +146,7 @@ const FroshController = {
       );
       query = {isRegistered: true };
       const frosh = await FroshServices.getFilteredFroshInfo(query, filter);
-
-      //Add code for reassigning users
-      mapFroshUsers(frosh, 0);
+      FroshServices.mapFroshUsers(frosh);
 
       return res.status(200).send({frosh});
 

--- a/server/src/routes/froshRoutes.js
+++ b/server/src/routes/froshRoutes.js
@@ -3,7 +3,7 @@ const express = require('express');
 const FroshController = require('../controllers/FroshController');
 const checkLoggedIn = require('../middlewares/checkLoggedIn');
 const checkUserType = require('../middlewares/checkUserType');
-
+const hasAuthScopes = require ("../middlewares/hasAuthScopes");
 const multer = require('multer');
 
 const storage = multer.memoryStorage();

--- a/server/src/routes/froshRoutes.js
+++ b/server/src/routes/froshRoutes.js
@@ -66,4 +66,12 @@ router.get(
   FroshController.getFilteredFroshInfo,
 );
 
+
+router.post(
+  '/reassign',
+  checkLoggedIn,
+  hasAuthScopes(['admin:all']),
+  FroshController.reassignFrosh,
+);
+
 module.exports = router;

--- a/server/src/routes/froshRoutes.js
+++ b/server/src/routes/froshRoutes.js
@@ -3,7 +3,7 @@ const express = require('express');
 const FroshController = require('../controllers/FroshController');
 const checkLoggedIn = require('../middlewares/checkLoggedIn');
 const checkUserType = require('../middlewares/checkUserType');
-const hasAuthScopes = require ("../middlewares/hasAuthScopes");
+const hasAuthScopes = require('../middlewares/hasAuthScopes');
 const multer = require('multer');
 
 const storage = multer.memoryStorage();
@@ -65,7 +65,6 @@ router.get(
   checkUserType('leadur'),
   FroshController.getFilteredFroshInfo,
 );
-
 
 router.post(
   '/redistribute',

--- a/server/src/routes/froshRoutes.js
+++ b/server/src/routes/froshRoutes.js
@@ -68,7 +68,7 @@ router.get(
 
 
 router.post(
-  '/reassign',
+  '/redistribute',
   checkLoggedIn,
   hasAuthScopes(['admin:all']),
   FroshController.reassignFrosh,


### PR DESCRIPTION
## **Contribution:**


### **Issue:**

Closes #679 

### **Accomplishments:**

- Created frosh route in `froshRoutes.js` for /reassign that uses the `hasAuthScopes` middleware to ensure that the 'admin:all' auth scope is present before allowing the user to reassign users.
- Created a function in FroshController called `reassignFrosh` that grabs all registered frosh(copy of getFilteredFroshInfo), and then recursively loops through and assigns new frosh groups to each user fetched if they have capital pronouns (ex She/Her instead of she/her). The recursion makes sure the same user will not get placed in the same group again.
- Created a simple page at `/frosh-redistribution` with a button to reassign users hooked up to redux (Made redistrubuteFroshSaga in /state/frosh/saga)

### **Visuals:** 

## **Details:**

### **Expected Behavior:**

- When the button is clicked (after it is made) it should shuffle up the frosh registered users into different groups based on the getNewFroshGroup function


### **Testing Steps:**

Steps required to get expected behavior.

- Create a leedur account, and manually add the `admin:all` scope so that you can access the `/frosh-redistribution` page
- Create some registered frosh to test the redistribution on, and manually set their pronouns to capitals (she/her -> She/Her)
- Navigate to /frosh-redistribution and click the button, and see if the frosh have been distributed to different groups.

### **Complications:**

- Still not sure if recursion is the best way to loop through the frosh and make sure they get new groups
- Still need to test with multiple registered frosh to ensure that it is shuffling correctly

### **Resources:**

Any additional resources used outside this in issue.

- resource 1
- resource 2
- resource 3
