### PR TITLE
651 create schedule pdfpng

### DIFF
--- a/client/src/assets/schedule/data.jsx
+++ b/client/src/assets/schedule/data.jsx
@@ -141,8 +141,8 @@
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -150,8 +150,8 @@
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -159,8 +159,8 @@
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -356,8 +356,8 @@ export const dataBeta = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -365,8 +365,8 @@ export const dataBeta = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -374,8 +374,8 @@ export const dataBeta = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -579,8 +579,8 @@ export const dataChi = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -588,8 +588,8 @@ export const dataChi = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -597,8 +597,8 @@ export const dataChi = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -690,7 +690,7 @@ export const dataDelta = {
       'Event Description':
         'Compete against other frosh groups in the craziest competitions imaginable',
       'Start Time': '12:30:00 a1/p1',
-      'End Time': '13:00:00  PM',
+      'End Time': '13:00:00 PM',
       Color: 'yellow',
     },
     {
@@ -802,8 +802,8 @@ export const dataDelta = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -811,8 +811,8 @@ export const dataDelta = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -820,8 +820,8 @@ export const dataDelta = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -1025,8 +1025,8 @@ export const dataGamma = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -1034,8 +1034,8 @@ export const dataGamma = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -1043,8 +1043,8 @@ export const dataGamma = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -1250,8 +1250,8 @@ export const dataIota = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -1259,8 +1259,8 @@ export const dataIota = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -1268,8 +1268,8 @@ export const dataIota = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -1475,8 +1475,8 @@ export const dataKappa = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -1484,8 +1484,8 @@ export const dataKappa = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -1493,8 +1493,8 @@ export const dataKappa = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -1700,8 +1700,8 @@ export const dataLambda = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -1709,8 +1709,8 @@ export const dataLambda = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -1718,8 +1718,8 @@ export const dataLambda = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -1925,8 +1925,8 @@ export const dataNu = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -1934,8 +1934,8 @@ export const dataNu = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -1943,8 +1943,8 @@ export const dataNu = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -2148,8 +2148,8 @@ export const dataOmega = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -2157,8 +2157,8 @@ export const dataOmega = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -2166,8 +2166,8 @@ export const dataOmega = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -2373,8 +2373,8 @@ export const dataOmicron = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -2382,8 +2382,8 @@ export const dataOmicron = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -2391,8 +2391,8 @@ export const dataOmicron = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -2596,8 +2596,8 @@ export const dataPhi = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -2605,8 +2605,8 @@ export const dataPhi = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -2614,8 +2614,8 @@ export const dataPhi = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -2821,8 +2821,8 @@ export const dataPi = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -2830,8 +2830,8 @@ export const dataPi = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -2839,8 +2839,8 @@ export const dataPi = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -3044,8 +3044,8 @@ export const dataPsi = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -3053,8 +3053,8 @@ export const dataPsi = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -3062,8 +3062,8 @@ export const dataPsi = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -3275,8 +3275,8 @@ export const dataRho = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -3284,8 +3284,8 @@ export const dataRho = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -3293,8 +3293,8 @@ export const dataRho = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -3506,8 +3506,8 @@ export const dataSigma = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -3515,8 +3515,8 @@ export const dataSigma = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -3524,8 +3524,8 @@ export const dataSigma = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -3737,8 +3737,8 @@ export const dataTau = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -3746,8 +3746,8 @@ export const dataTau = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -3755,8 +3755,8 @@ export const dataTau = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -3962,8 +3962,8 @@ export const dataTheta = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -3971,8 +3971,8 @@ export const dataTheta = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -3980,8 +3980,8 @@ export const dataTheta = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -4185,8 +4185,8 @@ export const dataUpsilon = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -4194,8 +4194,8 @@ export const dataUpsilon = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -4203,8 +4203,8 @@ export const dataUpsilon = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -4408,8 +4408,8 @@ export const dataZeta = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'This welcome session, brought to you by the First Year Office staff and guest speakers will help you to understand the first-year experience and your next steps as a new student. Open to all incoming first-year engineering students.',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'blue',
     },
     {
@@ -4417,8 +4417,8 @@ export const dataZeta = {
       'Event Location': 'Various Locations',
       'Event Description':
         'See the <a target="_blank" href=\'https://q.utoronto.ca/courses/171530\'>First Year Hub</a> for more details. These presentations will be followed by a free lunch and are brought to you by your department (i.e. ChemE, CivMin, ECE, MIE, MSE and TrackOne). They are a great chance to meet fellow first-year students in your engineering program and connect with key staff and faculty members.',
-      'Start Time': '11:00  AM',
-      'End Time': '1:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '1:00 PM',
       Color: 'purple',
     },
     {
@@ -4426,8 +4426,8 @@ export const dataZeta = {
       'Event Location': 'Bahen Lobby',
       'Event Description':
         'Interested in joining a club, intramural sport or getting involved with the Engineering Society (EngSoc)? Attend the Engineering Clubs Fair to learn more about the 100+ ways you can get involved. Event details can be found <a href="https://drive.google.com/file/d/1c3ScimduaMF3qtUlcbK5gA980gWyd-AO/view?usp=sharing">here</a>.',
-      'Start Time': '2:00  PM',
-      'End Time': '5:00  PM',
+      'Start Time': '2:00 PM',
+      'End Time': '5:00 PM',
       Color: 'yellow',
     },
     {
@@ -4486,8 +4486,8 @@ export const data = {
   'Monday September 4': [
     {
       'Event Name': 'Registration + Meet Your F!rosh Group',
-      'Start Time': '7:30  AM',
-      'End Time': '9:00  AM',
+      'Start Time': '7:30 AM',
+      'End Time': '9:00 AM',
       Color: 'purple',
     },
     {
@@ -4495,31 +4495,31 @@ export const data = {
       'Event Location': 'Convocation Hall',
       'Event Description':
         'Our kickoff to F!rosh Week, and an introduction to all things Skule! Hear from clubs, design teams, and other student groups about all the amazing opportunities waiting for you here at UofT Engineering, while also learning about some of our many Skule traditions!',
-      'Start Time': '9:00  AM',
-      'End Time': '11:00  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '11:00 AM',
       Color: 'yellow',
     },
     {
       'Event Name': 'F!rosh Games, D!ye Station & Lunch',
       'Event Description':
         'Frosh Games: Compete against other frosh groups in the craziest competitions imaginable.\nDye: When I say purple you say purple! Where F!rosh and Leedurs alike dye their bodies (or parts thereof) purple. The colour purple represents great significance in the traditions of engineering schools across Canada.',
-      'Start Time': '11:00  AM',
-      'End Time': '3:00  PM',
+      'Start Time': '11:00 AM',
+      'End Time': '3:00 PM',
       Color: 'purple',
     },
     {
       'Event Name': 'Downtown Walkaround',
       'Event Description':
         'Join us for a lovely tour of Toronto’s downtown with 1000 of your newest friends and classmates',
-      'Start Time': '3:00  PM',
-      'End Time': '6:00  PM',
+      'Start Time': '3:00 PM',
+      'End Time': '6:00 PM',
       Color: 'green',
     },
     {
       'Event Name': 'Nitelife & SUDS',
       'Event Description':
         'You thought F!rosh Week ended at 6:00pm? Think again! We have activities the Monday, Tuesday, and Friday of F!rosh Week for you to keep the hype going all week long!',
-      'Start Time': '6:00  PM',
+      'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',
     },
@@ -4529,29 +4529,29 @@ export const data = {
       'Event Name': 'Engineering Success Seminar',
       'Event Description':
         "Learn from some of your amazing new TA's about all the strategies you need to know for success here at UofT Engineering!",
-      'Start Time': '9:00  AM',
-      'End Time': '10:30  AM',
+      'Start Time': '9:00 AM',
+      'End Time': '10:30 AM',
       Color: 'gray',
     },
     {
       'Event Name': 'Campus Tour, Build Battle & Lunch',
       'Event Description':
         "Campus Tour: Be guided by your F!rosh Leedurs on a tour of our gorgeous campus, showing you all the best places to study, grab food, participate in extracurriculars, and nap! \nBuild Battle: Your first of many design challenges at UofT Engineering, except its probably the one of the coolest ones you do! Work with your frosh group to tackle your piece of the puzzle for this year's unique design challenge, coming together to build something truly amazing as a 2T7 class!",
-      'Start Time': '10:30  AM',
-      'End Time': '4:30  PM',
+      'Start Time': '10:30 AM',
+      'End Time': '4:30 PM',
       Color: 'yellow',
     },
     {
       'Event Name': 'Cheer Off',
-      'Start Time': '4:30  PM',
-      'End Time': '6:00  PM',
+      'Start Time': '4:30 PM',
+      'End Time': '6:00 PM',
       Color: 'purple',
     },
     {
       'Event Name': 'Nitelife & SUDS',
       'Event Description':
         'You thought F!rosh Week ended at 6:00pm? Think again! We have activities the Monday, Tuesday, and Friday of F!rosh Week for you to keep the hype going all week long!',
-      'Start Time': '6:00  PM',
+      'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',
     },
@@ -4559,15 +4559,15 @@ export const data = {
   'Wednesday September 6': [
     {
       'Event Name': 'Faculty Orientation & Skule Clubs Fair',
-      'Start Time': '9:00  AM',
-      'End Time': '6:00  PM',
+      'Start Time': '9:00 AM',
+      'End Time': '6:00 PM',
       Color: 'gray',
     },
     {
       'Event Name': 'Havenger Scunt',
       'Event Description':
         'Havenger Scunt: The longest items list you’ve ever seen. Join us for a full fledged scavenger hunt all over the city of Toronto!',
-      'Start Time': '6:00  PM',
+      'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',
     },
@@ -4575,8 +4575,8 @@ export const data = {
   'Thursday September 7': [
     {
       'Event Name': 'Class Starts',
-      'Start Time': '9:00  AM',
-      'End Time': '4:00  PM',
+      'Start Time': '9:00 AM',
+      'End Time': '4:00 PM',
       Color: 'gray',
     },
     {
@@ -4589,7 +4589,7 @@ export const data = {
     },
     {
       'Event Name': 'SUDS',
-      'Start Time': '6:00  PM',
+      'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',
     },
@@ -4597,15 +4597,15 @@ export const data = {
   'Friday September 8': [
     {
       'Event Name': 'Class Starts',
-      'Start Time': '9:00  AM',
-      'End Time': '6:00  PM',
+      'Start Time': '9:00 AM',
+      'End Time': '6:00 PM',
       Color: 'gray',
     },
     {
       'Event Name': 'Nitelife & SUDS',
       'Event Description':
         'You thought F!rosh Week ended at 6:00pm? Think again! We have activities the Monday, Tuesday, and Friday of F!rosh Week for you to keep the hype going all week long!',
-      'Start Time': '6:00  PM',
+      'Start Time': '6:00 PM',
       'End Time': 'Late',
       Color: 'dark-purple',
     },
@@ -4615,7 +4615,7 @@ export const data = {
       'Event Name': 'F!rosh Retreat',
       'Event Description':
         'Come with us out of the concrete jungle to enjoy a weekend of camp nostalgia, filled with swimming, games, campfires and more!',
-      'Start Time': '10:00  AM',
+      'Start Time': '10:00 AM',
       'End Time': 'Late',
       Color: 'purple',
     },

--- a/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
+++ b/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
@@ -1,56 +1,82 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { userSelector } from '../../state/user/userSlice';
-import { getDaysSchedule, getFroshGroupSchedule } from '../../pages/Profile/functions';
-import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+import React from 'react';
+import { getFroshGroupSchedule } from '../../pages/Profile/functions';
+import { Document, Page, Text, View, Svg, Line, Font, StyleSheet } from '@react-pdf/renderer';
+import MainFroshLogo from '../../assets/logo/frosh-main-logo-with-bg.svg';
 
 const styles = StyleSheet.create({
   page: {
     backgroundColor: '#E4E4E4',
   },
+  eventBubble: {
+    backgroundColor: '#58458f', 
+    borderRadius: '10px', 
+    padding: '10px', 
+    margin: '10px'
+  },
+  eventName: {
+    fontSize: 12, 
+    fontWeight: 'bold',
+    padding: '10px 0', 
+    color: '#fff'
+  },
+  eventLoc: {
+    fontSize: 12, 
+    padding: '10px 0', 
+    color: '#fff'
+  },
+  eventDate: {
+    fontSize: 11,
+    fontStyle: 'italic',
+    color: '#fff',
+    padding: '5px 0'
+  },
+  eventDesc: {
+    fontSize: 12, 
+    color: '#fff',
+    padding: '10px 0'
+  }
 });
 
-const MakeSchedulePDF = () => {
-  const { user } = useSelector(userSelector);
-  const [froshGroup, setFroshGroup] = useState(user?.froshGroup);
+const MakeSchedulePDF = (froshObject) => {
+  const froshGroup = froshObject?.froshGroup;
   const scheduleData = getFroshGroupSchedule(froshGroup);
-  const days = getDaysSchedule(scheduleData);
-  
+
   return (
     <Document>
-      <Page size="A4">
-        <View style={{ padding: '0 10px' }}>
-          <Text style={{ fontSize: 16, padding: '20px 0' }}>
+      <Page size="A4" style={styles.page}>
+        <View style={{ padding: '30px' }}>
+          <Text style={{ fontSize: 16, color: '#2c1370', padding: '20px 0', fontWeight: 'bold' }}>
             F!rosh Schedule 2T3
           </Text>
-          {scheduleData.map(day => (
-            <>
-              <Text style={{ fontSize: 14, padding: '20px 0' }}>
-                {day[0]}
+          <Svg height="10" width="500">
+            <Line x1="0" y1="0" x2="500" y2="0" strokeWidth={4} stroke="rgb(49,25,87)" />
+          </Svg>
+          {Object.keys(scheduleData).map((day) => (
+            <div key={day}>
+              <Text style={{ fontSize: 14, padding: '20px 0', color: '#2c1370', fontWeight: 'bold' }}>
+                {day}
               </Text>
-              {day.map(event => (
-                <>
-                  <Text style={{ fontSize: 12, padding: '20px 0' }}>
-                    {event['Event Name']}
+              {scheduleData[day].map((scheduleDay, index) => (
+                <div key={scheduleDay} style={styles.eventBubble}>
+                  <Text style={styles.eventName}>
+                    {scheduleDay['Event Name']}
                   </Text>
-                  <Text style={{ fontSize: 10, padding: '20px 0' }}>
-                    {event['Start Time']} - {event['End Time']}
+                  <Text style={styles.eventDate}>
+                    {scheduleDay['Start Time']} - {scheduleDay['End Time']}
                   </Text>
-                  {event['Event Location'] ? 
-                    <Text style={{ fontSize: 12, padding: '20px 0' }}>
-                      {event['Event Location']}
-                    </Text> :
-                    <> </>
+                  {scheduleDay['Event Location'] ? 
+                    <Text style={styles.eventLoc}>
+                      {scheduleDay['Event Location']}
+                    </Text> : <></>
                   }
-                  {event['Event Description'] ? 
-                    <Text style={{ fontSize: 12, padding: '20px 0' }}>
-                      {event['Event Description']}
-                    </Text> :
-                    <> </>
+                  {scheduleDay['Event Description'] ? 
+                    <Text style={styles.eventDesc}>
+                      {scheduleDay['Event Description']}
+                    </Text> : <></>
                   }
-                </>
+                </div>
               ))}
-            </>
+            </div>
           ))}
         </View>
       </Page>

--- a/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
+++ b/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+const { Document, Page, Text, View, StyleSheet } = import('@react-pdf/renderer');
+
+const styles = StyleSheet.create({
+  page: {
+    backgroundColor: '#E4E4E4',
+  },
+});
+
+const MakeSchedulePDF = () => {
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={{ padding: '0 10px' }}>
+          <Text style={{ fontSize: 16, padding: '20px 0' }}>
+            F!rosh Schedule 2T3
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+};
+
+export { MakeSchedulePDF };

--- a/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
+++ b/client/src/components/MakeSchedulePDF/MakeSchedulePDF.jsx
@@ -1,5 +1,8 @@
-import React from 'react';
-const { Document, Page, Text, View, StyleSheet } = import('@react-pdf/renderer');
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { userSelector } from '../../state/user/userSlice';
+import { getDaysSchedule, getFroshGroupSchedule } from '../../pages/Profile/functions';
+import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
 
 const styles = StyleSheet.create({
   page: {
@@ -8,13 +11,47 @@ const styles = StyleSheet.create({
 });
 
 const MakeSchedulePDF = () => {
+  const { user } = useSelector(userSelector);
+  const [froshGroup, setFroshGroup] = useState(user?.froshGroup);
+  const scheduleData = getFroshGroupSchedule(froshGroup);
+  const days = getDaysSchedule(scheduleData);
+  
   return (
     <Document>
-      <Page size="A4" style={styles.page}>
+      <Page size="A4">
         <View style={{ padding: '0 10px' }}>
           <Text style={{ fontSize: 16, padding: '20px 0' }}>
             F!rosh Schedule 2T3
           </Text>
+          {scheduleData.map(day => (
+            <>
+              <Text style={{ fontSize: 14, padding: '20px 0' }}>
+                {day[0]}
+              </Text>
+              {day.map(event => (
+                <>
+                  <Text style={{ fontSize: 12, padding: '20px 0' }}>
+                    {event['Event Name']}
+                  </Text>
+                  <Text style={{ fontSize: 10, padding: '20px 0' }}>
+                    {event['Start Time']} - {event['End Time']}
+                  </Text>
+                  {event['Event Location'] ? 
+                    <Text style={{ fontSize: 12, padding: '20px 0' }}>
+                      {event['Event Location']}
+                    </Text> :
+                    <> </>
+                  }
+                  {event['Event Description'] ? 
+                    <Text style={{ fontSize: 12, padding: '20px 0' }}>
+                      {event['Event Description']}
+                    </Text> :
+                    <> </>
+                  }
+                </>
+              ))}
+            </>
+          ))}
         </View>
       </Page>
     </Document>

--- a/client/src/components/profile/ProfilePageResources/ProfilePageResources.jsx
+++ b/client/src/components/profile/ProfilePageResources/ProfilePageResources.jsx
@@ -5,6 +5,7 @@ import './ProfilePageResources.scss';
 import PropTypes from 'prop-types';
 
 export const ProfilePageResources = ({ froshObject }) => {
+
   return (
     <div className="profile-page-resources profile-page-side-section">
       <h2>Resources</h2>
@@ -44,6 +45,19 @@ export const ProfilePageResources = ({ froshObject }) => {
       ) : (
         <></>
       )}
+      <ButtonBubble
+        label={'Download Schedule PDF'}
+        onClick={async () => {
+          const ReactPDF = await import('@react-pdf/renderer');
+          const { MakeSchedulePDF } = await import('../../MakeSchedulePDF/MakeSchedulePDF');
+          const blob = await ReactPDF.pdf(MakeSchedulePDF()).toBlob();
+          const fileURL = URL.createObjectURL(blob);
+          const pdfWindow = window.open(fileURL, '_blank');
+          pdfWindow && pdfWindow.focus();
+        }}
+        isSecondary
+        style={{ margin: 0, marginTop: '10px' }}
+      />
     </div>
   );
 };

--- a/client/src/components/profile/ProfilePageResources/ProfilePageResources.jsx
+++ b/client/src/components/profile/ProfilePageResources/ProfilePageResources.jsx
@@ -26,7 +26,8 @@ export const ProfilePageResources = ({ froshObject }) => {
           </a>
         );
       })}
-      {froshObject ? (
+      {froshObject ? ( 
+      <>
         <a key={'5Download'} className="no-link-style">
           <ButtonBubble
             label={'Download Information PDF'}
@@ -42,6 +43,7 @@ export const ProfilePageResources = ({ froshObject }) => {
             style={{ margin: 0, marginTop: '10px' }}
           />
         </a>
+      </>
       ) : (
         <></>
       )}
@@ -50,7 +52,7 @@ export const ProfilePageResources = ({ froshObject }) => {
         onClick={async () => {
           const ReactPDF = await import('@react-pdf/renderer');
           const { MakeSchedulePDF } = await import('../../MakeSchedulePDF/MakeSchedulePDF');
-          const blob = await ReactPDF.pdf(MakeSchedulePDF()).toBlob();
+          const blob = await ReactPDF.pdf(MakeSchedulePDF(froshObject)).toBlob();
           const fileURL = URL.createObjectURL(blob);
           const pdfWindow = window.open(fileURL, '_blank');
           pdfWindow && pdfWindow.focus();


### PR DESCRIPTION
## **Contribution:**

### **Issue:**
Closes #651 

### **Accomplishments:**
- Displayed a button on the profile page to display PDF on click.
- Got a PDF to appear using `@react-pdf/renderer` which includes each day's events planned for Frosh and their location, date, and description.

### **Visuals:** 
Profile Page:
![image](https://github.com/UofT-Frosh-Orientation/orientation-website/assets/109243682/19ddb247-3109-4aaf-83c3-eb8430f687de)

PDF:
![image](https://github.com/UofT-Frosh-Orientation/orientation-website/assets/109243682/3927c07e-029f-4a80-b468-cff763e68922)


## **Details:**

### **Expected Behavior:**
- After logging in, heading to profile page, and clicking the download button, you should be able to view the Schedule PDF in a separate tab.

### **Testing Steps:**

Steps required to get expected behavior.
- Run the backend and log in using a frosh account or remove `<AuthorizedPage>` tags in `util/pages.jsx`
- Head to profile page
- Click on 'Download Schedule PDF' button
- Check if the PDF is displayed as expected

### **Complications:**
- Wanted to clarify whether to only show this button if `froshObject == true`? (its outside that check right now)
- Was trying to change the colour according to the 'Color' field in `src/assets/data.jsx`. For some reason, it wouldn't work when I tried to put it as the background colour, so I just left it as some default purple in the stylesheet for now.
- There's some unknown characters in the event dates (shows as '//' in the PDF) that I'm not sure how to get rid of.
- Couldn't figure out how to use custom fonts or make font bold/italicized. I attempted registering the font but got a whole bunch of errors.

### **Resources:**
- ReactPDF font: [https://snyk.io/advisor/npm-package/@react-pdf/renderer/functions/@react-pdf%2Frenderer.Font.register](url)
