### PR TITLE
#697 - Add Points Curve in Scunt Game Settings

### DIFF
--- a/server/src/services/ScuntTeamServices.js
+++ b/server/src/services/ScuntTeamServices.js
@@ -56,10 +56,12 @@ const ScuntTeamServices = {
   },
 
   async calculatePoints(teamNumber, totalPoints) {
-    const teams = ScuntTeamModel.find({}, { name: 1, number: 1, points: 1 }, {}).sort({ points: -1 });
-    
+    const teams = ScuntTeamModel.find({}, { name: 1, number: 1, points: 1 }, {}).sort({
+      points: -1,
+    });
+
     const teamPosition = teams.map((t, pos) => {
-      if(teamNumber === t.number) {
+      if (teamNumber === t.number) {
         return pos + 1;
       }
     });
@@ -68,7 +70,7 @@ const ScuntTeamServices = {
   },
 
   async bribeTransaction(teamNumber, points, user) {
-    const curvedPoints = await calculatePoints(teamNumber, points);
+    const curvedPoints = await this.calculatePoints(teamNumber, points);
 
     return new Promise((resolve, reject) => {
       if (!user.scuntJudgeBribePoints || curvedPoints > user.scuntJudgeBribePoints) {
@@ -169,7 +171,7 @@ const ScuntTeamServices = {
   },
 
   async addTransaction(teamNumber, missionNumber, points) {
-    const curvedPoints = await calculatePoints(teamNumber, points);
+    const curvedPoints = await this.calculatePoints(teamNumber, points);
 
     return new Promise((resolve, reject) => {
       //TODO look up mission to get amount of points

--- a/server/src/services/ScuntTeamServices.js
+++ b/server/src/services/ScuntTeamServices.js
@@ -56,7 +56,7 @@ const ScuntTeamServices = {
   },
 
   async calculatePoints(teamNumber, totalPoints) {
-    const teams = ScuntTeamModel.find({}, { name: 1, number: 1, points: 1 }, {}).sort((a, b) => b.points - a.points);
+    const teams = ScuntTeamModel.find({}, { name: 1, number: 1, points: 1 }, {}).sort({ points: -1 });
     
     const teamPosition = teams.map((t, pos) => {
       if(teamNumber === t.number) {

--- a/server/src/services/ScuntTeamServices.js
+++ b/server/src/services/ScuntTeamServices.js
@@ -55,6 +55,12 @@ const ScuntTeamServices = {
     });
   },
 
+  async calculatePoints(teamPosition, points) {
+    const teams = [];
+    teams = getTeams();
+    return (teamPosition / teams.length) * points;
+  },
+
   async bribeTransaction(teamNumber, points, user) {
     return new Promise((resolve, reject) => {
       if (!user.scuntJudgeBribePoints || points > user.scuntJudgeBribePoints) {


### PR DESCRIPTION
## **Contribution:**

### **Issue:**
Closes #697 

### **Accomplishments:**
- Made a helper function called `calculatePoints` that takes in a `teamNumber` in the leaderboard and the `totalPoints` for a task
- `teamPosition` is found by finding, sorting, and mapping through Scunt Team array
- The function uses the formula `(teamPosition / numOfTeams) * totalPoints` and returns this newly calculated number of points

### **Visuals:** 
n/a

## **Details:**

### **Expected Behavior:**
- Should return a new points value according to the curve, higher position --> less points

### **Testing Steps:**
n/a

### **Complications:**
- I couldn't really figure out how to test this to see if it works so if there's some syntax errors or wrong variable usage, just let me know

### **Resources:**
- Farbod
