### PR TITLE
[DRAFT] #705 - Scunt Game Setting Services Tests

### DIFF
--- a/server/test/services/ScuntGameSettingsServices.test.js
+++ b/server/test/services/ScuntGameSettingsServices.test.js
@@ -5,6 +5,30 @@ const assert = require('assert');
 describe('Testing Scunt Game Settings Services', () => {
   let settings;
 
+  it('.setGameSettings()\t\t\t|\tSet invalid scunt game settings (INVALID SETTING)', async () => {
+    await assert.rejects(
+        ScuntGameSettingsServices.setGameSettings('Scunt2T3', 11, 2500, 0.3, true, true, true, true, 'url', true, true, true), {
+        name: 'Error',
+        message: 'UNABLE_TO_UPDATE_SCUNT_SETTINGS',
+    }, );
+  }); 
+
+  /*
+  it('.initScuntGameSettings()\t\t\t|\tFind an invalid scunt game setting (INVALID SETTING)', async () => {
+    const incorrectSetting = {
+        name: 'New Test Setting 12345',
+        amountOfTeams: 101,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+    };
+    await assert.rejects(ScuntGameSettingsServices.initScuntGameSettings(incorrectSetting), {
+      name: 'Error',
+      message: 'UNABLE_TO_GET_SCUNT_SETTINGS',
+    });
+  });
+  */
+  
   it('.initScuntGameSettings()\t\t\t|\tFind settings', async () => {
     const initialSettings = {
         name: 'Scunt2T3 Settings',
@@ -24,9 +48,9 @@ describe('Testing Scunt Game Settings Services', () => {
     assert(settings.amountOfTeams === 10);
   });
 
-  it('.initScuntGameSettings()\t\t\t|\tCreate new scunt game setting', async () => {
+  it('.initScuntGameSettings()\t\t\t|\tNew setting should not overwrite original Scunt setting', async () => {
     const newSetting = {
-        name: 'New Test Setting 12345',
+        name: 'New Test Setting 123456',
         amountOfTeams: 101,
         amountOfStarterBribePoints: 2500,
         maxAmountPointsPercent: 0.3,
@@ -38,12 +62,12 @@ describe('Testing Scunt Game Settings Services', () => {
         revealMissions: false,
         allowJudging: false,
     };
-    settings = await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
-    assert(settings.name === 'New Test Setting 12345');
-    assert(settings.amountOfTeams === 101);
+    
+    const testSettings = await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
+    assert(testSettings.name === 'Scunt2T3 Settings');
   });
 
-  it('.initScuntGameSettings()\t\t\t|\tFind existing/create new scunt game settings', async () => {
+  it('.initScuntGameSettings()\t\t\t|\tFind existing/create new scunt game settings consecutively', async () => {
     const newSetting = {
         name: 'New Test Setting 12345',
         amountOfTeams: 101,
@@ -76,20 +100,6 @@ describe('Testing Scunt Game Settings Services', () => {
     await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
     await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
     await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
-  });
-
-  it('.initScuntGameSettings()\t\t\t|\tFind an invalid scunt game setting (INVALID SETTING)', async () => {
-    const incorrectSetting = {
-        name: 'New Test Setting 12345',
-        amountOfTeams: 101,
-        amountOfStarterBribePoints: 2500,
-        maxAmountPointsPercent: 0.3,
-        minAmountPointsPercent: 0.3,
-    };
-    await assert.rejects(ScuntGameSettingsServices.initScuntGameSettings(incorrectSetting), {
-      name: 'Error',
-      message: 'UNABLE_TO_GET_SCUNT_SETTINGS',
-    });
   });
 
   /* couldn't think of test case for getGameSettings for it not to work besides network error */
@@ -113,11 +123,6 @@ describe('Testing Scunt Game Settings Services', () => {
     await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 10, 2500, 0.3, 0.3, true, true, true, true, true, true);
   });
 
-  it('.setGameSettings()\t\t\t|\tSet invalid scunt game settings (INVALID SETTING)', async () => {
-    await assert.rejects(
-        ScuntGameSettingsServices.setGameSettings(11, 2500, 0.3, 0.3, true, true, true, true, true, true ), {
-        name: 'Error',
-        message: 'UNABLE_TO_UPDATE_SCUNT_SETTINGS',
-    });
-  });
+  
+  
 });

--- a/server/test/services/ScuntGameSettingsServices.test.js
+++ b/server/test/services/ScuntGameSettingsServices.test.js
@@ -1,0 +1,123 @@
+/* eslint-disable no-undef */
+const ScuntGameSettingsServices = require('../../src/services/ScuntGameSettingsServices');
+const assert = require('assert');
+
+describe('Testing Scunt Game Settings Services', () => {
+  let settings;
+
+  it('.initScuntGameSettings()\t\t\t|\tFind settings', async () => {
+    const initialSettings = {
+        name: 'Scunt2T3 Settings',
+        amountOfTeams: 10,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+        revealJudgesAndBribes: true,
+        revealTeams: true,
+        showDiscordLink: true,
+        revealLeaderboard: true,
+        revealMissions: true,
+        allowJudging: true,
+    };
+    settings = await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+    assert(settings.name === 'Scunt2T3 Settings');
+    assert(settings.amountOfTeams === 10);
+  });
+
+  it('.initScuntGameSettings()\t\t\t|\tCreate new scunt game setting', async () => {
+    const newSetting = {
+        name: 'New Test Setting 12345',
+        amountOfTeams: 101,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+        revealJudgesAndBribes: true,
+        revealTeams: true,
+        showDiscordLink: false,
+        revealLeaderboard: true,
+        revealMissions: false,
+        allowJudging: false,
+    };
+    settings = await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
+    assert(settings.name === 'New Test Setting 12345');
+    assert(settings.amountOfTeams === 101);
+  });
+
+  it('.initScuntGameSettings()\t\t\t|\tFind existing/create new scunt game settings', async () => {
+    const newSetting = {
+        name: 'New Test Setting 12345',
+        amountOfTeams: 101,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+        revealJudgesAndBribes: true,
+        revealTeams: true,
+        showDiscordLink: false,
+        revealLeaderboard: true,
+        revealMissions: false,
+        allowJudging: false,
+    };
+    const initialSettings = {
+        name: 'Scunt2T3 Settings',
+        amountOfTeams: 10,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+        revealJudgesAndBribes: true,
+        revealTeams: true,
+        showDiscordLink: true,
+        revealLeaderboard: true,
+        revealMissions: true,
+        allowJudging: true,
+    };
+    await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
+    await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
+    await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
+    await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+    await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+    await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+  });
+
+  it('.initScuntGameSettings()\t\t\t|\tFind an invalid scunt game setting (INVALID SETTING)', async () => {
+    const incorrectSetting = {
+        name: 'New Test Setting 12345',
+        amountOfTeams: 101,
+        amountOfStarterBribePoints: 2500,
+        maxAmountPointsPercent: 0.3,
+        minAmountPointsPercent: 0.3,
+    };
+    await assert.rejects(ScuntGameSettingsServices.initScuntGameSettings(incorrectSetting), {
+      name: 'Error',
+      message: 'UNABLE_TO_GET_SCUNT_SETTINGS',
+    });
+  });
+
+  /* couldn't think of test case for getGameSettings for it not to work besides network error */
+  it('.getGameSettings()\t\t\t|\tGet scunt game settings', async () => {
+    settings = await ScuntGameSettingsServices.getGameSettings();
+    assert(settings !== null);
+  });
+
+  it('.setGameSettings()\t\t\t|\tSet scunt game settings', async () => {
+    settings = await ScuntGameSettingsServices.setGameSettings(
+        'Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, true, true, true, true );
+    assert(settings.name === 'Scunt2T3 Settings');
+    assert(settings.amountOfTeams === 11);
+  });
+
+  it('.setGameSettings()\t\t\t|\tSet multiple scunt game settings', async () => {
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, true, true, true, true);
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 10, 2500, 0.3, 0.3, true, true, true, true, true, true);
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, false, true, false, true);
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, false, true, false, true, false, true);
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 10, 2500, 0.3, 0.3, true, true, true, true, true, true);
+  });
+
+  it('.setGameSettings()\t\t\t|\tSet invalid scunt game settings (INVALID SETTING)', async () => {
+    await assert.rejects(
+        ScuntGameSettingsServices.setGameSettings(11, 2500, 0.3, 0.3, true, true, true, true, true, true ), {
+        name: 'Error',
+        message: 'UNABLE_TO_UPDATE_SCUNT_SETTINGS',
+    });
+  });
+});

--- a/server/test/services/ScuntGameSettingsServices.test.js
+++ b/server/test/services/ScuntGameSettingsServices.test.js
@@ -12,23 +12,8 @@ describe('Testing Scunt Game Settings Services', () => {
         message: 'UNABLE_TO_UPDATE_SCUNT_SETTINGS',
     }, );
   }); 
-
-  /*
-  it('.initScuntGameSettings()\t\t\t|\tFind an invalid scunt game setting (INVALID SETTING)', async () => {
-    const incorrectSetting = {
-        name: 'New Test Setting 12345',
-        amountOfTeams: 101,
-        amountOfStarterBribePoints: 2500,
-        maxAmountPointsPercent: 0.3,
-        minAmountPointsPercent: 0.3,
-    };
-    await assert.rejects(ScuntGameSettingsServices.initScuntGameSettings(incorrectSetting), {
-      name: 'Error',
-      message: 'UNABLE_TO_GET_SCUNT_SETTINGS',
-    });
-  });
-  */
   
+  /* couldn't think of test case for initScuntGameSettings for it not to work besides network error */
   it('.initScuntGameSettings()\t\t\t|\tFind settings', async () => {
     const initialSettings = {
         name: 'Scunt2T3 Settings',
@@ -99,13 +84,16 @@ describe('Testing Scunt Game Settings Services', () => {
     await ScuntGameSettingsServices.initScuntGameSettings(newSetting);
     await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
     await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
-    await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+    const testSettings = await ScuntGameSettingsServices.initScuntGameSettings(initialSettings);
+    assert(testSettings.name === 'Scunt2T3 Settings');
   });
 
   /* couldn't think of test case for getGameSettings for it not to work besides network error */
   it('.getGameSettings()\t\t\t|\tGet scunt game settings', async () => {
     settings = await ScuntGameSettingsServices.getGameSettings();
     assert(settings !== null);
+    assert(settings.name === 'Scunt2T3 Settings');
+    assert(settings.amountOfStarterBribePoints === 2500);
   });
 
   it('.setGameSettings()\t\t\t|\tSet scunt game settings', async () => {
@@ -118,11 +106,10 @@ describe('Testing Scunt Game Settings Services', () => {
   it('.setGameSettings()\t\t\t|\tSet multiple scunt game settings', async () => {
     await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, true, true, true, true);
     await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 10, 2500, 0.3, 0.3, true, true, true, true, true, true);
-    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, false, true, false, true);
-    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, false, true, false, true, false, true);
+    await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 11, 2500, 0.3, 0.3, true, true, false, true, true, true);
+    const testSettings = await ScuntGameSettingsServices.setGameSettings(
+      'Scunt2T3 Settings', 11, 2400, 0.3, 0.3, false, true, false, true, false, true);
+    assert(testSettings.amountOfStarterBribePoints === 2400);
     await ScuntGameSettingsServices.setGameSettings('Scunt2T3 Settings', 10, 2500, 0.3, 0.3, true, true, true, true, true, true);
   });
-
-  
-  
 });


### PR DESCRIPTION
## **Contribution:**

### **Issue:**
Closes #705 

### **Accomplishments:**
- Made tests for functions in `ScuntGameSettingsServices.js`: `initScuntGameSettings`, `getGameSettings`, and `setGameSettings`
### **Visuals:** 
n/a

## **Details:**

### **Expected Behavior:**
- All cases should pass when testing

### **Testing Steps:**
- Run docker command, cd server, yarn test
- Check if all tests for ScuntGameSettingsServices.test.js are passing

### **Complications:**
- I wasn't able to think of error cases for the functions `initScuntGameSettings` and `getGameSettings`, possibly because it might involve having network errors?

### **Resources:**
n/a
