### PR TITLE
updated social links, Gamma and Pi accounts still need to be set up

### DIFF
--- a/client/src/util/instagramAccounts.jsx
+++ b/client/src/util/instagramAccounts.jsx
@@ -1,22 +1,22 @@
 export const instagramAccounts = {
-  Alpha: 'https://www.instagram.com/alpha_frosh_2t3/',
-  Beta: 'https://www.instagram.com/beta_frosh_2t3/',
-  Iota: 'https://www.instagram.com/iota_frosh_2t3/',
-  Phi: 'https://www.instagram.com/phi_frosh_2t3/',
-  Psi: 'https://www.instagram.com/psi_frosh_2t3/', ////not available
-  Rho: 'https://www.instagram.com/rho_frosh_2t3/',
-  Zeta: 'https://www.instagram.com/zeta_frosh_2t3/',
-  Gamma: 'https://www.instagram.com/gamma_frosh_2t3/',
-  Omega: 'https://www.instagram.com/omega_frosh_2t3/', ////not available
-  Chi: 'https://www.instagram.com/chi_frosh_2t3/',
-  Upsilon: 'https://www.instagram.com/upsilon_frosh_2t3/',
-  Pi: 'https://www.instagram.com/pi_frosh_2t3/',
-  Nu: 'https://www.instagram.com/nu_frosh_2t3/',
-  Delta: 'https://www.instagram.com/delta_frosh_2t3/',
-  Sigma: 'https://www.instagram.com/sigma_frosh_2t3/',
-  Tau: 'https://www.instagram.com/tau_frosh_2t3/', ////not available
-  Kappa: 'https://www.instagram.com/kappa_frosh_2t3/',
-  Theta: 'https://www.instagram.com/theta_frosh_2t3/',
-  Lambda: 'https://www.instagram.com/lambda_frosh_2t3/',
-  Omicron: 'https://www.instagram.com/omicron_frosh_2t3/',
+  Alpha: 'https://www.instagram.com/alpha_frosh_2t4/',
+  Beta: 'https://www.instagram.com/beta_frosh_2t4/',
+  Iota: 'https://www.instagram.com/iota_frosh_2t4/',
+  Phi: 'https://www.instagram.com/phi_frosh_2t4/',
+  Psi: 'https://www.instagram.com/psi_frosh_2t4/',
+  Rho: 'https://www.instagram.com/rho_frosh_2t4/',
+  Zeta: 'https://www.instagram.com/zeta_frosh_2t4/',
+  Gamma: 'https://www.instagram.com/gamma_frosh_2t4/', //not available
+  Omega: 'https://www.instagram.com/omega_frosh_2t4/',
+  Chi: 'https://www.instagram.com/chi_frosh_2t4/',
+  Upsilon: 'https://www.instagram.com/upsilon_frosh_2t4/',
+  Pi: 'https://www.instagram.com/pi_frosh_2t4/', //not available
+  Nu: 'https://www.instagram.com/nu_frosh_2t4/',
+  Delta: 'https://www.instagram.com/delta_frosh_2t4/',
+  Sigma: 'https://www.instagram.com/sigma_frosh_2t4/',
+  Tau: 'https://www.instagram.com/tau_frosh_2t4/',
+  Kappa: 'https://www.instagram.com/kappa_frosh_2t4/',
+  Theta: 'https://www.instagram.com/theta_frosh_2t4/',
+  Lambda: 'https://www.instagram.com/lambda_frosh_2t4/',
+  Omicron: 'https://www.instagram.com/omicron_frosh_2t4/',
 };


### PR DESCRIPTION
## **Contribution:**

updated social links in the  [orientation-website/client/src/util/instagramAccounts.jsx](https://github.com/UofT-Frosh-Orientation/orientation-website/blob/dev/client/src/util/instagramAccounts.jsx) file

Gamma and Pi accounts still need to be set up, the two links for Gamma and Pi do not work
