### PR TITLE
Update About Us Page to Show Vice Chairs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,7 +17,7 @@ import { getUserInfo } from './state/user/saga';
 
 import { LandingPage } from './pages/Initial/LandingPage';
 
-const readyForFrosh = false;
+const readyForFrosh = true;
 
 export default function App() {
   const dispatch = useDispatch();

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -1,24 +1,27 @@
-import {
-  React,
-  // useState
-} from 'react';
+import { React, useState } from 'react';
 import './About.scss';
+//import { Carousel } from 'react-responsive-carousel';
+//import "react-responsive-carousel/lib/styles/carousel.min.css";
+
+//import MultiCarousel from 'react-multi-carousel';
+//import 'react-multi-carousel/lib/styles.css';
 
 import { aboutUsInfo } from '../../util/about/aboutus';
-// import { execInfo } from '../../util/about/execs';
+import { execInfo } from '../../util/about/execs';
+
 // import { techTeam } from '../../util/about/techteam';
 // import { headLeedurs } from '../../util/about/headleedurs';
 // import { subComs } from '../../util/about/subcoms';
 
-// import { ExecProfile } from './ExecProfile/ExecProfile';
+import { ExecProfile } from './ExecProfile/ExecProfile';
 import ExecLogo from '../../assets/about/about-page.svg';
-// import { useEffect } from 'react';
-// import { object } from 'prop-types';
+import { useEffect } from 'react';
+import { object } from 'prop-types';
 import { Header } from '../../components/text/Header/Header';
 
-// import InstagramIcon from '../../assets/social/instagram-brands.svg';
-// import MailIcon from '../../assets/social/envelope-solid.svg';
-// import { instagramAccounts } from '../../util/instagramAccounts';
+import InstagramIcon from '../../assets/social/instagram-brands.svg';
+import MailIcon from '../../assets/social/envelope-solid.svg';
+import { instagramAccounts } from '../../util/instagramAccounts';
 
 // import PropTypes from 'prop-types';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
@@ -70,57 +73,56 @@ const AboutUsSection = () => {
   );
 };
 
-// const OCSection = () => {
-//   return (
-//     <div className="aboutus-oc-container">
-//       {[execInfo.oc].map((info) => {
-//         return (
-//           <ExecProfile
-//             key={info.name}
-//             image={info.image}
-//             name={info.name}
-//             role={info.role}
-//             discipline={info.discipline}
-//             roleDescription={info.description}
-//             favPart={info.favPart}
-//             exec={true}
-//           />
-//         );
-//       })}
-//     </div>
-//   );
-// };
+const OCSection = () => {
+  return (
+    <div className="aboutus-oc-grid-container">
+      {[...execInfo.ocs].map((info) => {
+        return (
+          <ExecProfile
+            key={info.name}
+            className="oc-grid-item"
+            image={info.image}
+            name={info.name}
+            role={info.role}
+            discipline={info.discipline}
+            roleDescription={info.description}
+            exec={true}
+          />
+        );
+      })}
+    </div>
+  );
+};
 
-// const VCSection = () => {
-//   return (
-//     <div className="aboutus-vc-grid-container">
-//       {[...execInfo.vcs].map((info) => {
-//         return (
-//           <ExecProfile
-//             key={info.name}
-//             className="vc-grid-item"
-//             image={info.image}
-//             name={info.name}
-//             role={info.role}
-//             discipline={info.discipline}
-//             roleDescription={info.description}
-//             favPart={info.favPart}
-//             exec={true}
-//           />
-//         );
-//       })}
-//     </div>
-//   );
-// };
+const VCSection = () => {
+  return (
+    <div className="aboutus-vc-grid-container">
+      {[...execInfo.vcs].map((info) => {
+        return (
+          <ExecProfile
+            key={info.name}
+            className="vc-grid-item"
+            image={info.image}
+            name={info.name}
+            role={info.role}
+            discipline={info.discipline}
+            roleDescription={info.description}
+            exec={true}
+          />
+        );
+      })}
+    </div>
+  );
+};
 
-// const AboutUsExecTeam = () => {
-//   return (
-//     <>
-//       <OCSection />
-//       <VCSection />
-//     </>
-//   );
-// };
+const AboutUsExecTeam = () => {
+  return (
+    <>
+      <OCSection />
+      <VCSection />
+    </>
+  );
+};
 
 // const AboutUsTechTeam = () => {
 //   let count = 0;
@@ -283,12 +285,13 @@ const AboutUsSection = () => {
 // };
 
 const tabs = [
-  // {
-  //   title: 'Exec Team',
-  //   component: <AboutUsExecTeam />,
-  //   active: true,
-  //   wantToLoad: false,
-  // },
+  {
+    title: 'Exec Team',
+    component: <AboutUsExecTeam />,
+    active: true,
+    wantToLoad: true,
+  },
+
   // {
   //   title: 'Tech Team',
   //   component: <AboutUsTechTeam />,
@@ -309,98 +312,98 @@ const tabs = [
   // },
 ];
 
-// const AboutUsTeamsTab = () => {
-//   const wantedTabs = tabs.filter((tab) => tab.wantToLoad);
+const AboutUsTeamsTab = () => {
+  const wantedTabs = tabs.filter((tab) => tab.wantToLoad);
 
-//   const [currentTab, setCurrentTab] = useState(
-//     wantedTabs.length > 0 ? wantedTabs.at(0).title : 'Exec Team',
-//   );
+  const [currentTab, setCurrentTab] = useState(
+    wantedTabs.length > 0 ? wantedTabs.at(0).title : 'Exec Team',
+  );
 
-//   let tabsCounter = 0;
-//   let numTabs = tabs.length;
-//   let tabComponent;
+  let tabsCounter = 0;
+  let numTabs = tabs.length;
+  let tabComponent;
 
-//   return (
-//     <>
-//       <div className="aboutus-teams-all-tabs">
-//         <div className="aboutus-teams-all-tabs-scroll">
-//           {tabs.map((tab) => {
-//             if (tab.active) {
-//               tabsCounter++;
+  return (
+    <>
+      <div className="aboutus-teams-all-tabs">
+        <div className="aboutus-teams-all-tabs-scroll">
+          {tabs.map((tab) => {
+            if (tab.active) {
+              tabsCounter++;
 
-//               return (
-//                 <div key={tab.title} className="aboutus-teams-tabs">
-//                   <div
-//                     className="aboutus-teams-tabs-container"
-//                     onClick={() => {
-//                       setCurrentTab(tab.title);
-//                     }}
-//                   >
-//                     {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
-//                     <div
-//                       style={{
-//                         display: 'flex',
-//                         flexDirection: 'column',
-//                         justifyContent: 'start',
-//                       }}
-//                     >
-//                       <h1
-//                         className={
-//                           currentTab === tab.title
-//                             ? 'aboutus-teams-tabs-title-selected'
-//                             : 'aboutus-teams-tabs-title'
-//                         }
-//                       >
-//                         {tab.title}
-//                       </h1>
-//                       <div
-//                         className={`aboutus-yellow-bubble ${
-//                           currentTab === tab.title
-//                             ? 'aboutus-yellow-bubble-show'
-//                             : 'aboutus-yellow-bubble-noshow'
-//                         }`}
-//                       ></div>
-//                     </div>
-//                   </div>
-//                 </div>
-//               );
-//             } else {
-//               return;
-//             }
-//           })}
-//         </div>
-//       </div>
+              return (
+                <div key={tab.title} className="aboutus-teams-tabs">
+                  <div
+                    className="aboutus-teams-tabs-container"
+                    onClick={() => {
+                      setCurrentTab(tab.title);
+                    }}
+                  >
+                    {tabsCounter > 1 ? <div className="aboutus-short-vertical-line"></div> : <></>}
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'start',
+                      }}
+                    >
+                      <h1
+                        className={
+                          currentTab === tab.title
+                            ? 'aboutus-teams-tabs-title-selected'
+                            : 'aboutus-teams-tabs-title'
+                        }
+                      >
+                        {tab.title}
+                      </h1>
+                      <div
+                        className={`aboutus-yellow-bubble ${
+                          currentTab === tab.title
+                            ? 'aboutus-yellow-bubble-show'
+                            : 'aboutus-yellow-bubble-noshow'
+                        }`}
+                      ></div>
+                    </div>
+                  </div>
+                </div>
+              );
+            } else {
+              return;
+            }
+          })}
+        </div>
+      </div>
 
-//       <div className="aboutus-tabs-component">
-//         {tabs.map((tab) => {
-//           if (currentTab === tab.title && tab.active) {
-//             return tab.component;
-//           }
-//         })}
-//       </div>
-//     </>
-//   );
-// };
+      <div className="aboutus-tabs-component">
+        {tabs.map((tab) => {
+          if (currentTab === tab.title && tab.active) {
+            return tab.component;
+          }
+        })}
+      </div>
+    </>
+  );
+};
 
 const AboutUsTeamsTabWrapper = () => {
-  // let showAboutUs = false;
+  let showAboutUs = true;
 
-  // tabs.map((tab) => (tab.active = showAboutUs ? tab.wantToLoad : false));
+  tabs.map((tab) => (tab.active = showAboutUs ? tab.wantToLoad : false));
 
   // set showAboutUs in case every single tab is false
 
-  // showAboutUs = !tabs.every((tab, i, a) => !tab.wantToLoad);
+  showAboutUs = !tabs.every((tab, i, a) => !tab.wantToLoad);
 
-  // return (
-  //   <>
-  //     {showAboutUs ? (
-  //       <AboutUsTeamsTab />
-  //     ) : (
-  //       <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>
-  //     )}
-  //   </>
-  // );
-  return <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>;
+  return (
+    <>
+      {showAboutUs ? (
+        <AboutUsTeamsTab />
+      ) : (
+        <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>
+      )}
+    </>
+  );
+  //return <h2 className="about-introduction-title">Stay tuned to meet the team!</h2>;
 };
 
 export { PageAbout };

--- a/client/src/pages/About/About.scss
+++ b/client/src/pages/About/About.scss
@@ -157,11 +157,22 @@
 }
 
 // VC GRID
-.aboutus-oc-container {
-  display: flex;
-  width: 100%;
+.aboutus-oc-grid-container {
+  display: grid;
+  width: 90vw;
+  grid-template-columns: repeat(auto-fit, 450px);
+  align-items: center;
+  justify-items: center;
   justify-content: center;
-  justify-self: center;
+  margin-bottom: 25px;
+
+  @include devices(tablet) {
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: none;
+    justify-content: center;
+    align-items: center;
+  }
 }
 .aboutus-vc-grid-container {
   display: grid;
@@ -479,4 +490,159 @@
   text-align: center;
   color: var(--black);
   margin-bottom: 20px;
+}
+
+/*creating the properties of the arrows and where they are located*/
+.aboutus-arrows {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+/*creating the properties of the arrow button*/
+.aboutus-arrow-btn {
+  background-color: #ffffff;
+  color: #6f1f85;
+  font-family: 'Staatliches', sans-serif;
+  border: 0px solid #6f1f8500;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+/*changing the properties of the arrow button if mouse hovers*/
+.aboutus-arrow-btn:hover {
+  background-color: #6f1f85;
+  color: #fcc606;
+}
+
+/* Team slide */
+.team-slide {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+/* Customize slick dots */
+.slick-dots li button:before {
+  color: var(--purple-shades-dark);
+}
+
+.slick-dots li.slick-active button:before {
+  color: #f3d384;
+}
+
+/* Customize slick arrows */
+.slick-prev:before,
+.slick-next:before {
+  color: var(--purple-shades-dark);
+}
+
+.carousel .slide {
+  display: flex;
+  justify-content: center;
+}
+
+.carousel-slide-container {
+  padding: 20px;
+}
+
+.carousel-slide-border {
+  padding: 15px;
+  border-radius: 15px;
+  margin-bottom: 55px;
+  cursor: pointer;
+  height: calc(350px - 50px);
+
+  @include devices(tablet) {
+    width: 100%;
+    margin-bottom: 40px;
+    height: calc(290px - 50px);
+  }
+}
+
+.carousel-slide {
+  background-color: var(--white);
+  padding: 15px;
+  border-radius: 15px;
+  margin-bottom: 55px;
+  cursor: pointer;
+  height: calc(320px - 50px);
+  @include devices(tablet) {
+    width: 80%;
+    margin-bottom: 40px;
+    height: calc(260px - 50px);
+  }
+
+  object-fit: contain;
+}
+
+.control-dots {
+  .dot {
+    background: var(--control-dot) !important;
+    box-shadow: unset !important;
+    width: 40px !important;
+    height: 6px !important;
+    margin: 0 0px !important;
+    border-radius: 0 !important;
+    @include devices(tablet) {
+      width: 20px !important;
+      height: 5px !important;
+    }
+  }
+}
+
+.carousel-link {
+  background: none;
+  display: block;
+  transition: transform 300ms;
+}
+
+.carousel-link:hover {
+  transform: scale(1.05);
+  transition: transform 300ms;
+}
+
+.all-teams-tabs-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.aboutus-tabs-component {
+  margin-top: 20px;
+}
+
+/* AboutUsTeamsCarousel styles */
+.aboutus-teams-carousel {
+  margin: 20px auto;
+  max-width: 800px; /* Adjust the maximum width as needed */
+}
+
+.aboutus-teams-carousel-tab {
+  padding: 10px;
+  border-radius: 5px;
+  background-color: #f0f0f0; /* Background color for the carousel tabs */
+  margin-right: 10px; /* Adjust the right margin as needed */
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.aboutus-teams-carousel-tab h1 {
+  margin: 0;
+  font-size: 16px;
+  color: #333; /* Tab text color */
+}
+
+.aboutus-teams-carousel-tab.active {
+  background-color: #007bff; /* Active tab background color */
+}
+
+.aboutus-teams-carousel-tab.active h1 {
+  color: #fff; /* Active tab text color */
 }

--- a/client/src/pages/About/ExecProfile/ExecProfile.jsx
+++ b/client/src/pages/About/ExecProfile/ExecProfile.jsx
@@ -18,7 +18,6 @@ const ExecProfile = ({
   discipline,
   roleDescription,
   description,
-  favPart,
   exec,
   quote,
   subcom,
@@ -56,7 +55,6 @@ const ExecProfile = ({
             role={role}
             discipline={discipline}
             roleDescription={roleDescription}
-            favPart={favPart}
           />
         ) : subcom ? (
           <SubcomProfileDescription name={name} description={roleDescription} cochairs={cochairs} />
@@ -82,7 +80,7 @@ const ExecProfileTitle = ({ name, role }) => {
   );
 };
 
-const ExecProfileDescription = ({ name, role, discipline, roleDescription, favPart }) => {
+const ExecProfileDescription = ({ name, role, discipline, roleDescription }) => {
   return (
     <div className="exec-profile-description">
       <div className="exec-profile-title-cont">
@@ -96,15 +94,9 @@ const ExecProfileDescription = ({ name, role, discipline, roleDescription, favPa
       </p>
 
       <p className="exec-profile-description-role">
-        <span style={{ fontWeight: 'bold' }}>MY ROLE: </span>
+        <span style={{ fontWeight: 'bold' }}> FUN FACTS: </span>
         <br></br>
         {roleDescription}
-      </p>
-
-      <p className="exec-profile-description-fav">
-        <span style={{ fontWeight: 'bold' }}>MY FAVOURITE PART: </span>
-        <br></br>
-        {favPart}
       </p>
     </div>
   );
@@ -216,7 +208,6 @@ ExecProfile.propTypes = {
 
   discipline: PropTypes.string,
   roleDescription: PropTypes.string,
-  favPart: PropTypes.string,
   quote: PropTypes.string,
   cochairs: PropTypes.array, // list of subcom members
 
@@ -237,7 +228,6 @@ ExecProfileDescription.propTypes = {
   role: PropTypes.string,
   discipline: PropTypes.string,
   roleDescription: PropTypes.string,
-  favPart: PropTypes.string,
 };
 
 ScuntJudgeDescription.propTypes = {

--- a/client/src/pages/About/ExecProfile/ExecProfile.scss
+++ b/client/src/pages/About/ExecProfile/ExecProfile.scss
@@ -165,8 +165,7 @@
 }
 
 .exec-profile-description-dis,
-.exec-profile-description-role,
-.exec-profile-description-fav {
+.exec-profile-description-role {
   color: var(--white);
 }
 

--- a/client/src/pages/Initial/AsmitaLanding/AsmitaLanding.scss
+++ b/client/src/pages/Initial/AsmitaLanding/AsmitaLanding.scss
@@ -9,7 +9,8 @@
   overflow-y: hidden;
   overflow-x: hidden;
 
-  background-image: url('../AsmitaLanding/images/AsmitaLandingBackDrop.png');
+  background-image: url('/workspaces/orientation-website/client/src/pages/Initial/AsmitaLanding/images/AsmitaLandingBackDrop.png');
+
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center center;

--- a/client/src/util/about/execs.jsx
+++ b/client/src/util/about/execs.jsx
@@ -1,127 +1,94 @@
-import ocPhoto from '../../assets/about/execs/oc.jpg';
-import vcFinance from '../../assets/about/execs/vc_finance.jpg';
-import vcInternal from '../../assets/about/execs/vc_internal.jpg';
-import vcLeadership from '../../assets/about/execs/vc_leadership.jpg';
-import vcLogistics from '../../assets/about/execs/vc_logistics.jpg';
-import vcMarketing from '../../assets/about/execs/vc_marketing.jpg';
-import vcOperations from '../../assets/about/execs/vc_operations.jpg';
+import oc1Photo from '../../assets/about/execs/co-oc1.jpg';
+import oc2Photo from '../../assets/about/execs/co-oc2.jpg';
+import vcFinance from '../../assets/about/execs/vcfinance.jpg';
+import vcEvents1 from '../../assets/about/execs/vcevents1.jpg';
+import vcEvents2 from '../../assets/about/execs/vcevents2.jpg';
+import vcLeadership from '../../assets/about/execs/vcleadership.jpg';
+import vcMarketing from '../../assets/about/execs/vcmarketing.jpg';
 
 export const execInfo = {
-  oc: {
-    name: 'Kerryn Van Rooyen',
-    role: 'Orientation Chair',
-    discipline: 'EngSci (Physics) 2T2 + PEY',
-    image: ocPhoto,
-    description: `I'm Kerryn and I get to be your Orientation Chair this year! I have the pleasure 
-    of working with our other lovely execs and overseeing the hundreds of volunteers it takes to 
-    make your F!rosh week epic!
+  ocs: [
+    {
+      name: ' Lily VanderWoude',
+      role: 'Orientation Chair',
+      discipline: 'Mech 2T5 + PEY ',
+      image: oc1Photo,
+      description: `Some fun facts about me are: I’m a Mech 2T5 + PEY (previously T1!) specialized in the Mechatronics 
+    & Solid Mechanics streams 😎. I worked as a full-time librarian during my gap year before uni 🤓 (some of you 
+    may recall story time with Lily during Godiva Week 😌). I am a nature-enthusiast who enjoys rock climbing 🧗‍♀️ & 
+    camping 🏕️ & hiking 🌿. My brother and I raised money for the Canadian Cancer Society to shave our heads in 2022 
+    for my aunt fighting cancer (note the range of hairstyles 🫢). I was Vice Chair Community for F!rosh Week 2T3, a 
+    2T2 Alpha Leedur & I cannot wait to be your Co-OC 2T4!! 🥹
+
     `,
-    favPart: `Now that I'm an old dinosaur, my favourite part of F!rosh Week is working with the incredible 
-    people behind the scenes to make this event happen. When I was a frosh, my favourite part was the sense 
-    of community I felt as everyone dyed purple and then paraded around downtown; it made me feel like Toronto 
-    was my new home, and these were my new people! That feeling has lasted long past F!rosh week, and I am so 
-    excited for you all to experience it too!
+    },
+
+    {
+      name: 'Vedant Gupta',
+      role: 'Orientation Chair',
+      discipline: 'EngSci (Aerospace) 2T5 + PEY',
+      image: oc2Photo,
+      description: `Some fun facts about me are: I play the trumpet (among many other instruments. I have a black belt 
+    in taekwondo (woah). You’ll probably have seen me around in a variety of things including but not limited to: UTFR, 
+    Skulenite, Engineering Outreach Office, BnG Contest during Godiva Week, etc. I have lived in 6 countries since I was 
+    born. I am an avid watcher and supporter of formula one (diehard McLaren fan, don’t come at me, Lando first win this year)
     `,
-  },
+    },
+  ],
+
   vcs: [
     {
-      name: 'Amy Bagrin',
+      name: 'Mehak Afzal',
       role: 'Vice-Chair Finance',
-      discipline: ' CIV 2T4 + PEY',
+      discipline: ' Mech 2T5 + PEY',
       image: vcFinance,
-      description: `I'm Amy, and as your Vice-Chair Finance, I get to do three things - raise money, 
-      spend money, and deliver the things we bought with the money to you, the F!rosh!
-      `,
-      favPart: `Everybody always says this, but it's so true - the people are the best part of F!rosh Week. 
-      And there's nothing wilder than seeing hundreds of those people come together as a community on the 
-      streets of downtown Toronto, the spirit and energy are truly unmatched! I can't wait to see the sea 
-      of yellow hardhats and t-shirts again in September :)
+      description: `Some fun facts about me are: You may have (hopefully) seen me around skule in a variety of 
+      activities ranging from club events by WISE, UTEK and UTESCA to Design teams and being an Engineering E-buddy. 
+      Apart from skule, which is hard to detach from, I enjoy playing tennis (though I’m still a rookie), watching 
+      K-dramas, sipping on boba, delving into philosophy, and indulging in plenty of coffee (it’s a lifestyle).
+
       `,
     },
+
     {
-      name: 'Matthew Wilson',
-      role: 'VC Internal',
-      discipline: 'EngSci (MSF) 2T3 + PEY',
-      image: vcInternal,
-      description: `Hi, I’m Matt and my role this year is Vice-Chair Internal! I oversee a diverse mish-mash 
-      of SubComs that work on all things from the website you’re reading this on, to the sign in on day one 
-      of Frosh Week. So if you’re commuting in with a Frosh paired friend, asking a question to our Frosh 
-      email, reading all about Frosh Week on this site, or just signing up for Frosh Week then think of me 
-      and make sure to be thankful to our incredible volunteers that make this all happen!
-      `,
-      favPart: `The truth is I’m not much of a cheers, chants, and running around dyed purple kinda guy so my 
-      favourite part of Frosh Week is a little more low key. For me it’s all about welcoming a new group of 
-      engineers into our wonderful community. We have hundreds of volunteers at all levels of the Orientation 
-      Committee that work tirelessly all summer, for free, because we honestly all love Frosh Week, 
-      the community, and you 2T6s. We’re so excited to have you all here, we can’t wait to show you around 
-      your new home away from home, and I especially am thrilled to be able to welcome you into being a U of T 
-      engineer.
-      `,
-    },
-    {
-      name: 'Julianne Attai',
+      name: 'Olivia Fredrickson',
       role: 'VC Leadership',
-      discipline: 'EngSci (Robo) 2T3 + PEY',
+      discipline: 'Mech 2T4+1 + PEY',
       image: vcLeadership,
-      description: `Hiya folks! I’m Julianne, and I’m this year’s Vice-Chair Leadership! My job is to oversee 
-      the training of all the leedurs, head leedurs and volunteers you meet during Frosh Week (around 800 people!). 
-      Specifically, I oversee the leadership portfolio who develops training for topics like leadership development, 
-      equity diversity & inclusion and mental health and wellness, as well as supporting the Head Leedurs as they get 
-      their groups ready for Frosh Week (you’ll surely see crazy purple folks running around campus during the day).
-      `,
-      favPart: `My favourite part of Frosh Week is always getting to meet new people within Skule (even though the 
-      2T5s make me feel like a dinosaur). If I had to pick one event, I have a soft spot for Matriculation because 
-      there’s something whimsical and magical about having 1000 engineers take their hard hat oath together in Con 
-      Hall
+      description: `Some fun facts about me are: I studied at the University of Sydney in the fall, I played 
+      hockey for 13 years, I had purple hair when I was little, and 17 kittens were born on my family farm 
+      within five days
       `,
     },
+
     {
-      name: 'Jordan Greenberg',
-      role: 'VC Logistics',
-      discipline: 'ECE 2T2 + PEY',
-      image: vcLogistics,
-      description: `Hello! I’m Jordan, this year’s Vice-Chair Logistics. This means I get to help organize many 
-      of the HYPE events during F!rosh week, including Campus Tours, Downtown Walkaround, D!ye Station, Havenger Scunt, 
-      and F!rosh Retreat. I also work with Skule Patrol, the lovely people that keep us all safe!
-      `,
-      favPart: `As the oldest dinosaur, I have seen many different sides of F!rosh Week. When I was a frosh, I didn’t 
-      know anyone and was nervous coming into this new environment. F!rosh Week showed me even though our Skule™ community 
-      is made up of people from all walks of life, there truly is a place for everyone! I remember feeling so supported by my 
-      new classmates and the upper year students who were introducing us to UofT Engineering. There are so many amazing people 
-      that are part of F!rosh Week, and I love coming together to show off our special Skule™ community. From dyeing purple to 
-      cheering while we walk the streets of Toronto, F!rosh Week is truly a special experience. I am so excited to help make this 
-      year another F!rosh Week to remember!
-      `,
-    },
-    {
-      name: 'Kate Whelan',
+      name: 'Victoria Zhou',
       role: 'VC Marketing',
-      discipline: ' EngSci (ECE) 2T3 + PEY',
+      discipline: ' EngSci (BME) 2T5 + PEY',
       image: vcMarketing,
-      description: `I’m Kate and I have the honour of being your Vice Chair Marketing this year for F!rosh Week! I have the 
-      absolute coolest portfolio that I get to work with that runs everything from social media to photography to creating 
-      all our awesome logos to our outreach program!! You’ll see lots from us in the weeks leading up to F!rosh week, aka the best 
-      week of the year!!
-      `,
-      favPart: `I’m going to cheat and have two answers. As a frosh my favourite part was the Cheer Off it was the culmination of 
-      2 days getting to know all these people and traditions. Getting to yell and cheer with all my new friends and be welcomed 
-      into the community was possibly the best way to start my university experience. Now as a Dino my favourite part of frosh is 
-      getting to meet all of you! I love hearing about all your new hopes for starting university, it’s the one time we are all on 
-      campus together without class to worry about and it lets us just have fun for a week!
+      description: `Some fun facts about me are: I grew up dancing and doing rhythmic gymnastics 💃 Being from 
+      Alberta I love going to the mountains and hiking 🏔️ I love mac & cheese (even though I’m lactose intolerant) 
+      and if you can’t find me, I’m probably in the bathroom with a nosebleed
       `,
     },
     {
-      name: 'Aidan Torres',
-      role: 'VC Operations',
-      discipline: 'Mech 2T4 + PEY',
-      image: vcOperations,
-      description: `Hey Hey! I’m Aidan, and I’m Vice-Chair Operations for this year’s Frosh Week!!!! I get to oversee half 
-      of the LogOps (logistics and operations) portfolio which encompasses all the events that occur during Frosh Week! 
-      (Matriculation, Frosh Games, Bermuda Triangle, Engineers for the World, The Nest and Nitelife!)
+      name: 'Simona Tenche',
+      role: 'VC Events',
+      discipline: 'MSE 2T6 + PEY',
+      image: vcEvents1,
+      description: `Some fun facts about me are: I love cats and baking, and if you ever want to get on my good side 
+      you should definitely bring me a coffee (hehe). You’ll often find me in the hhc or engstores where I work, 
+      so feel free to pop in and say hi!!
       `,
-      favPart: `Other than of course everything, Frosh Week allows you to build some connections both with Frosh and Leedurs 
-      that last throughout your time at Skule. Some of the people I met during my own frosh week are still my best friends 
-      to this day! Of course, the wild and wacky traditions of Skule make for some epic bonding moments :)
+    },
+    {
+      name: 'Katherine Elder',
+      role: 'VC Events',
+      discipline: 'EngSci (Physics) 2T5 + PEY',
+      image: vcEvents2,
+      description: `Some fun facts about me are: I’ve been a leedur and DTW subcom, co-directed nocturne, I enjoy singing 
+      (in choir and alone in my room), riding horses, dragon boating (go ID) and being outside. I also drink close 
+      to a daily hot chocolate in the winter months.
       `,
     },
   ],


### PR DESCRIPTION
## **Contribution:**
About folder, and Exec Profile Folder both updated and modified by me. Implemented all OC and VC profiles, and ensure the same template can be used for other frosh subdivisions. Also fixed landing page error with background image.

### **Issue:**
Issue #765 : Update the About Us Page.

Closes # 
(idk what this means)

### **Accomplishments:**

- Shows vice chairs 
- Can interact for more information
- Displays all members dynamically

### **Visuals:** 
<img width="959" alt="Screenshot 2024-06-18 043931" src="https://github.com/UofT-Frosh-Orientation/orientation-website/assets/105055090/e4ac7d5e-1fcf-4ad4-bd33-8b9a7bbf095b">

### **Expected Behavior:**

- Information should dynamically change across devices
- Information should be interactable with both cursor and touch
- About us page structure should be consistent if more teams were to be added

### **Testing Steps:**


### **Complications:**

- Could not change layout as I would have to restrucre entire code (including tabs layout)
- Could not implement the enchanted theme due to time constraints

