### PR TITLE
FAQ search changed to search for term in answers too

### DIFF
--- a/client/src/pages/FAQ/FAQ.jsx
+++ b/client/src/pages/FAQ/FAQ.jsx
@@ -213,7 +213,7 @@ const FAQPageHeader = ({
       return questions;
     }
     return questions.filter((question) => {
-      const questionName = question.question.toLowerCase();
+      const questionName = question.question.toLowerCase() + question.answer.toLowerCase();
       return questionName.includes(query.toLowerCase());
     });
   };


### PR DESCRIPTION
## **Contribution:**
FAQ search changed to also search for term in answers

### **Issue:**
Initially the search function on the FAQ page would only show results where the term appeared in the question. The Tech Team decided it might be more useful for the user to be able to search for the term in the answers as well. 

### **Accomplishments:**

N/A

### **Visuals:** 

N/A

## **Details:**

### **Expected Behavior:**

- The FAQ search should now return questions with the search query in the question or answer.

### **Testing Steps:**

Steps required to get expected behavior.

- Search for a common term (ex. "skule") within the FAQ, the results should also display questions with the term only in the answer.

### **Complications:**

N/A

### **Resources:**

Any additional resources used outside this in issue.

N/A
