### PR TITLE
FAQ Page Redesign

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,7 +21,7 @@ import { ComingSoon } from './pages/Initial/ComingSoon/ComingSoon';
 
 // Set to false to take over the whole site with the single Coming Soon page
 // (no router, navbar or footer). Flip back to true to restore the full app.
-const readyForFrosh = false;
+const readyForFrosh = true;
 
 export default function App() {
   const dispatch = useDispatch();

--- a/client/src/pages/FAQ/FAQ.jsx
+++ b/client/src/pages/FAQ/FAQ.jsx
@@ -99,7 +99,7 @@ const PageFAQ = () => {
   );
 
   return (
-    <div className="bg-primary">
+    <div className="bg-primary" data-theme={darkMode ? 'dark' : 'light'}>
       <div>
         <FAQPageHeader
           questions={unsortedQuestions}

--- a/client/src/pages/FAQ/FAQ.jsx
+++ b/client/src/pages/FAQ/FAQ.jsx
@@ -84,27 +84,19 @@ const PageFAQ = () => {
   }, []);
 
   useEffect(() => {
-    // Reset current page to 1 when category (activeIndex) changes
     setCurrentPage(1);
   }, [activeIndex]);
 
-  // Calculate total pages
   const totalPages = Math.ceil((allQuestions[activeIndex]?.length || 0) / itemsPerPage);
 
-  // Handle page change
   const handlePageChange = (page) => {
     setCurrentPage(page);
   };
 
-  // Get current page questions
   const currentQuestions = allQuestions[activeIndex]?.slice(
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage,
   );
-
-  console.log('Current Page:', currentPage);
-  console.log('Total Pages:', totalPages);
-  console.log('Current Questions:', currentQuestions);
 
   return (
     <div className="bg-primary">
@@ -122,34 +114,28 @@ const PageFAQ = () => {
           setActiveIndex={setActiveIndex}
           questionCategories={questionCategories}
         />
-        {/* {darkMode ? (
-          <img src={WaveDarkMode} className={'faq-wave-image faq-page-top-wave-image'} />
-        ) : (
-          <img src={Wave} className={'faq-wave-image faq-page-top-wave-image'} />
-        )} */}
         {errorLoading ? <h1 className="faq-error-text">There was an error loading FAQs</h1> : <></>}
+
         {loading ? (
           <LoadingAnimation size={'55px'} />
         ) : (
-          <div
-            className={`faq-button-selector-container ${
-              isSearch ? 'faq-hide-button-selector' : 'faq-show-button-selector'
-            }`}
-          >
-            <FAQButtons
-              activeIndex={activeIndex}
-              setActiveIndex={setActiveIndex}
-              setIsSearch={setIsSearch}
-              setIsMultiSearch={setIsMultiSearch}
-              setSearchQuery={setSearchQuery}
-              questionCategories={questionCategories}
-            />
-          </div>
-        )}
-        {loading ? (
-          <></>
-        ) : (
-          <>
+          /* Wrap sidebar and accordions together inside the flex row container */
+          <div className="faq-content-row">
+            <div
+              className={`faq-button-selector-container ${
+                isSearch ? 'faq-hide-button-selector' : 'faq-show-button-selector'
+              }`}
+            >
+              <FAQButtons
+                activeIndex={activeIndex}
+                setActiveIndex={setActiveIndex}
+                setIsSearch={setIsSearch}
+                setIsMultiSearch={setIsMultiSearch}
+                setSearchQuery={setSearchQuery}
+                questionCategories={questionCategories}
+              />
+            </div>
+
             <div
               className={`faq-accordion-container ${
                 isSearch ? 'faq-hide-accordion' : 'faq-show-accordion'
@@ -160,12 +146,17 @@ const PageFAQ = () => {
                 activeIndex={activeIndex}
                 setActiveIndex={setActiveIndex}
               />
-              {/* <PaginationControls
-                currentPage={currentPage}
-                totalPages={totalPages}
-                handlePageChange={handlePageChange}
-              /> */}
+
+              {/* Added missing pagination controls underneath the accordion list */}
+              {totalPages > 1 && (
+                <PaginationControls
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  handlePageChange={handlePageChange}
+                />
+              )}
             </div>
+
             <div
               className={`faq-display-questions-container ${
                 isSearch ? 'faq-show-accordion' : 'faq-hide-accordion'
@@ -187,7 +178,7 @@ const PageFAQ = () => {
                 <h1>No results</h1>
               </div>
             </div>
-          </>
+          </div>
         )}
       </div>
       <div className="fill bg-primary">filler</div>
@@ -305,12 +296,12 @@ FAQPageHeader.propTypes = {
   setIsSearch: PropTypes.func.isRequired,
   searchQuery: PropTypes.string.isRequired,
   setSearchQuery: PropTypes.func.isRequired,
-  selectedSearchResult: PropTypes.number.isRequired,
-  setSelectedSearchResult: PropTypes.bool.isRequired,
+  selectedSearchResult: PropTypes.bool.isRequired, // Changed from number to bool
+  setSelectedSearchResult: PropTypes.func.isRequired, // Changed from bool to func
   setSelectedQuestions: PropTypes.func.isRequired,
   setIsMultiSearch: PropTypes.func.isRequired,
   setIsNoMatch: PropTypes.func.isRequired,
-  setActiveIndex: PropTypes.number.isRequired,
+  setActiveIndex: PropTypes.func.isRequired, // Changed from number to func
   questionCategories: PropTypes.array.isRequired,
 };
 
@@ -334,6 +325,7 @@ const FAQButtons = ({
         setActiveIndex={setActiveIndex}
         maxWidthButton={200}
         classNameSelector={'faq-button-selector'}
+        classNameButton={'faq-button-selector-btn'}
       />
     </div>
   );
@@ -367,12 +359,28 @@ const FAQAccordionWrapper = ({ scheduleData, openStatus, activeIndex }) => {
   useEffect(() => {
     setIsOpen(false);
   }, [activeIndex]);
+
   return (
     <SingleAccordion
       isOpen={isOpen}
       setIsOpen={setIsOpen}
-      header={<div className={'faq-search-result-question-accordion'}>{scheduleData.question}</div>}
-      style={{ backgroundColor: 'var(--faq-answer-containers)', padding: '0px 30px 0px 30px' }}
+      header={
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            width: '100%',
+            alignItems: 'center',
+          }}
+        >
+          <div className={'faq-search-result-question-accordion'}>{scheduleData.question}</div>
+          {/* Plus / Minus sign swap match */}
+          <span style={{ color: 'var(--mikado)', fontSize: '24px', fontWeight: 'bold' }}>
+            {isOpen ? '−' : '+'}
+          </span>
+        </div>
+      }
+      style={{ backgroundColor: 'transparent' }}
       className="accordion-clickable"
       dark={true}
     >
@@ -440,11 +448,11 @@ FAQSearchBar.propTypes = {
   questions: PropTypes.array.isRequired,
   selectedSearchResult: PropTypes.bool.isRequired,
   setSelectedSearchResult: PropTypes.func.isRequired,
-  setIsNoMatch: PropTypes.bool.isRequired,
+  setIsNoMatch: PropTypes.func.isRequired, // Changed from bool to func
   setSelectedQuestions: PropTypes.func.isRequired,
 };
 
-const FAQDisplayAllSearchQuestion = ({ selectedQuestions, questions }) => {
+const FAQDisplayAllSearchQuestion = ({ selectedQuestions }) => {
   const allSearchQuestions = selectedQuestions.map((question, index) => (
     <div key={index} className={'faq-search-result-container'}>
       <div className={'faq-search-result-question'}>{question.question}</div>
@@ -456,7 +464,6 @@ const FAQDisplayAllSearchQuestion = ({ selectedQuestions, questions }) => {
 
 FAQDisplayAllSearchQuestion.propTypes = {
   selectedQuestions: PropTypes.array.isRequired,
-  questions: PropTypes.array.isRequired,
 };
 
 const PaginationControls = ({ currentPage, totalPages, handlePageChange }) => (

--- a/client/src/pages/FAQ/FAQ.jsx
+++ b/client/src/pages/FAQ/FAQ.jsx
@@ -31,6 +31,10 @@ const PageFAQ = () => {
   const [loading, setLoading] = useState(true);
   const [errorLoading, setErrorLoading] = useState(false);
   const { setSnackbar } = useContext(SnackbarContext);
+  const [isAdding, setIsAdding] = useState(false); // Controls form panel visibility
+  const [newQuestion, setNewQuestion] = useState('');
+  const [newAnswer, setNewAnswer] = useState('');
+  const [newCategory, setNewCategory] = useState('');
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -98,6 +102,41 @@ const PageFAQ = () => {
     currentPage * itemsPerPage,
   );
 
+  const handleAddQuestionSubmit = async (e) => {
+    e.preventDefault();
+    if (!newQuestion || !newAnswer || !newCategory) {
+      setSnackbar('Please fill out all fields');
+      return;
+    }
+
+    // 1. Structure the new item payload
+    const freshQuestion = {
+      question: newQuestion,
+      answer: newAnswer,
+      category: newCategory.trim().toUpperCase(), // Keeping categories uniform
+    };
+
+    try {
+      // 2. OPTIONAL: If you have an API route to save to a database, uncomment this:
+      // await saveQuestionToBackend(freshQuestion, setSnackbar);
+
+      // 3. Update local states so it shows up in the UI immediately without a page reload
+      setUnsortedQuestions((prev) => [...prev, { ...freshQuestion, id: prev.length }]);
+
+      // Re-trigger your existing loadQuestions pipeline to safely regenerate category mappings and pages
+      await loadQuestions();
+
+      // 4. Reset form fields and close the view
+      setNewQuestion('');
+      setNewAnswer('');
+      setNewCategory('');
+      setIsAdding(false);
+      setSnackbar('Question added successfully!');
+    } catch (err) {
+      setSnackbar('Failed to add the question');
+    }
+  };
+
   return (
     <div className="bg-primary" data-theme={darkMode ? 'dark' : 'light'}>
       <div>
@@ -114,6 +153,58 @@ const PageFAQ = () => {
           setActiveIndex={setActiveIndex}
           questionCategories={questionCategories}
         />
+
+        {/* --- ADD NEW QUESTION PANEL TRIGGER --- */}
+        <div
+          className="faq-add-trigger-container"
+          style={{ maxWidth: '1000px', margin: '15px auto', padding: '0 20px' }}
+        >
+          {' '}
+          <button className="faq-add-trigger-btn" onClick={() => setIsAdding(!isAdding)}>
+            {isAdding ? '✕ Close Form' : '＋ Add New Question'}
+          </button>
+        </div>
+
+        {isAdding && (
+          <form onSubmit={handleAddQuestionSubmit} className="faq-add-form-panel">
+            <h3>Create a New FAQ Entry</h3>
+
+            <div className="form-group">
+              <label>Category</label>
+              <input
+                type="text"
+                placeholder="e.g. REGISTRATION, GENERAL"
+                value={newCategory}
+                onChange={(e) => setNewCategory(e.target.value)}
+              />
+            </div>
+
+            <div className="form-group">
+              <label>Question</label>
+              <input
+                type="text"
+                placeholder="What is the question?"
+                value={newQuestion}
+                onChange={(e) => setNewQuestion(e.target.value)}
+              />
+            </div>
+
+            <div className="form-group">
+              <label>Answer Text</label>
+              <textarea
+                placeholder="Provide the detailed answer here..."
+                value={newAnswer}
+                onChange={(e) => setNewAnswer(e.target.value)}
+                rows={4}
+              />
+            </div>
+
+            <button type="submit" className="faq-submit-btn">
+              Publish Question
+            </button>
+          </form>
+        )}
+
         {errorLoading ? <h1 className="faq-error-text">There was an error loading FAQs</h1> : <></>}
 
         {loading ? (

--- a/client/src/pages/FAQ/FAQ.scss
+++ b/client/src/pages/FAQ/FAQ.scss
@@ -571,3 +571,99 @@
 .fill {
   display: none;
 }
+
+// --- ADD QUESTION FEATURE UI STYLES ---
+.faq-add-trigger-btn {
+  background-color: var(--faq-accent) !important;
+  color: var(--faq-bg) !important;
+  font-family: 'Gliker', Impact, sans-serif;
+  text-transform: uppercase;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.03);
+  }
+}
+
+.faq-add-trigger-container {
+  position: relative;
+  z-index: 10;
+}
+
+.faq-add-form-panel {
+  max-width: 1000px;
+  margin: 15px auto 30px auto;
+  width: calc(100% - 40px);
+  background-color: var(--faq-panel-bg);
+  border: 3px solid var(--faq-accent);
+  border-radius: 20px;
+  padding: 25px;
+  box-sizing: border-box;
+
+  position: relative;
+  z-index: 10; // Lifts it clean above the background layers
+
+  @include devices(tablet) {
+    padding: 15px;
+    border-radius: 15px;
+  }
+
+  h3 {
+    color: var(--faq-accent);
+    font-family: 'Gliker', Impact, sans-serif;
+    text-transform: uppercase;
+    margin-top: 0;
+    margin-bottom: 20px;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+
+    label {
+      color: var(--faq-text);
+      font-family: 'Gliker', Impact, sans-serif;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    input,
+    textarea {
+      background-color: rgba(0, 0, 0, 0.15);
+      border: 1px solid rgba(255, 211, 0, 0.2);
+      border-radius: 10px;
+      padding: 12px;
+      color: var(--faq-text);
+      font-size: 14px;
+      font-family: system-ui, sans-serif;
+
+      &:focus {
+        outline: none;
+        border-color: var(--faq-accent);
+      }
+    }
+  }
+
+  .faq-submit-btn {
+    background-color: var(--faq-accent);
+    color: var(--faq-bg);
+    font-family: 'Gliker', Impact, sans-serif;
+    text-transform: uppercase;
+    border: none;
+    width: 100%;
+    padding: 14px;
+    border-radius: 12px;
+    font-size: 16px;
+    cursor: pointer;
+    margin-top: 10px;
+  }
+}

--- a/client/src/pages/FAQ/FAQ.scss
+++ b/client/src/pages/FAQ/FAQ.scss
@@ -1,383 +1,559 @@
 @import '../../scssStyles/mixins';
 
 :root {
-  --faq-pixel-border: url('../../assets/faq/faq-pixel-border-light.png');
+  --faq-bg-dark: #3d0f58; // Adjusted to match Figma's deep purple background
+  --faq-checker-purple: #460f64;
+  --mikado: #ffd300; // Figma Yellow
+  --text-white: #ffffff;
+  --checker-dark: #3d0f58;
+  --checker-light: #711f8b;
 }
 
-.dark-mode {
-  --faq-pixel-border: url('../../assets/faq/faq-pixel-border-dark.png');
-}
-
+// Outer page body wrapper context
 .bg-primary {
-  background-color: var(--bg-primary);
-}
-
-.fill {
+  background-color: var(--faq-bg-dark) !important;
+  position: relative;
   width: 100%;
-  height: 100%;
-  text-align: center;
-  font-size: 1px;
-  color: var(--bg-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-sizing: border-box;
+
+  // --- BACKGROUND CHECKER BOARDS ---
+  &::before {
+    content: '';
+    position: absolute;
+    top: -88vh; // <-- changed from -53% to -53vh
+    left: 10vh; // width-based %, fine to keep — width doesn't change between categories
+    width: 39%;
+    height: 200vh; // <-- changed from 125% to 125vh
+    background-image: linear-gradient(
+        45deg,
+        var(--checker-light) 25%,
+        transparent 25%,
+        transparent 75%,
+        var(--checker-light) 75%
+      ),
+      linear-gradient(
+        45deg,
+        var(--checker-light) 25%,
+        transparent 25%,
+        transparent 75%,
+        var(--checker-light) 75%
+      );
+    background-size: 100px 100px;
+    background-position: 0 0, 50px 50px;
+    transform: rotate(70deg);
+    z-index: 1;
+    pointer-events: none;
+
+    @include devices(tablet) {
+      width: 46%;
+      height: 125vh;
+      transform: rotate(70deg);
+      background-size: 100px 100px;
+      background-position: 0 0, 50px 50px;
+
+      top: -415px;
+      left: 11vh; // Locks your horizontal position to the height axis so it never drifts
+    }
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: -24vh; // <-- changed from -23% to -23vh
+    right: -38vh;
+    width: 35%;
+    height: 150vh; // <-- changed from 150% to 150vh
+    background-image: linear-gradient(
+        45deg,
+        var(--checker-light) 25%,
+        transparent 25%,
+        transparent 75%,
+        var(--checker-light) 75%
+      ),
+      linear-gradient(
+        45deg,
+        var(--checker-light) 25%,
+        transparent 25%,
+        transparent 75%,
+        var(--checker-light) 75%
+      );
+    background-size: 100px 100px;
+    background-position: 0 0, 50px 50px;
+    transform: rotate(-20deg);
+    z-index: 1;
+    pointer-events: none;
+
+    @include devices(tablet) {
+      width: 47%;
+      height: 150vh;
+      transform: rotate(-20deg);
+      background-size: 100px 100px;
+      background-position: 0 0, 50px 50px;
+
+      top: -62px;
+      right: -28vh; // Locks your horizontal position to the height axis so it never drifts
+    }
+  }
 }
 
+// --- HEADER SECTIONS ---
 .faq-page-header {
   position: relative;
-  max-height: 700px;
-  height: 50vh;
-  min-height: 400px;
-  background-color: var(--bg-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  z-index: 5;
+  padding: 60px 10% 0px 10%;
+  width: 100%;
+  box-sizing: border-box;
 
   @include devices(tablet) {
-    margin-top: 0px;
-    height: 40vh;
-    min-height: 300px;
+    padding: 40px 5% 0 5%;
   }
 }
 
 .faq-page-header-container {
-  width: 80%;
-  @include devices(tablet) {
-    width: 90%;
-  }
-}
-
-.faq-button-selector-container {
-  margin: 0px 5% 0px 5%;
-  background-color: var(--bg-primary);
-
-  @media only screen and (max-height: 850px) {
-    margin-top: 20px;
-  }
-}
-
-.faq-button-selector {
-  @media (min-width: 1034px) {
-    justify-content: center !important;
-  }
-  @include devices(tablet) {
-    padding-top: 20px !important;
-  }
-}
-
-.faq-error-text {
-  margin: 10px 20px;
-  text-align: center;
-  color: var(--text-primary) !important;
-}
-
-.faq-hide-button-selector {
-  display: none;
-}
-
-.faq-show-button-selector {
-  display: block;
-}
-
-.faq-display-questions-container {
-  margin: 50px 10% 100px 10%;
-  width: 80%;
+  max-width: 1000px; // Tightened to match the Figma proportion
+  margin: 0 auto;
+  position: relative;
+  z-index: 6;
 }
 
 .faq-page-header-text {
   h1 {
-    font-size: 90px;
-    color: var(--text-primary);
-    font-weight: 800;
-    margin-bottom: 20px;
-    margin-top: 80px;
+    font-size: 120px;
+    font-family: 'Gliker', Impact, sans-serif; // Swap with your exact Figma display font
+    color: var(--mikado);
+    font-weight: 900;
+    margin: 0 0 10px 0;
+    text-transform: uppercase;
+    display: inline-block;
+    letter-spacing: 5px;
+
+    // The solid Neobrutalist block shadow from Figma
+    text-shadow: 3px 3px 3px #1e052d, 6px 6px 6px #1e052d, 9px 9px 6px #1e052d,
+      12px 12px 0px #1e052d;
+
+    @include devices(tablet) {
+      font-size: 54px; // Shrinks the giant FAQ title so it doesn't blow out mobile
+      letter-spacing: 2px;
+      text-shadow: 2px 2px 0px #1e052d, 4px 4px 0px #1e052d;
+    }
   }
-  h2 {
-    font-size: 50px;
-    color: var(--text-primary);
-    line-height: 0.7;
-  }
+
   p {
-    font-size: 25px;
-    color: var(--text-primary);
-    font-weight: 700;
+    display: none; // Hidden because it doesn't appear in the Figma target design
   }
 }
 
+// --- CONNECTED SEARCH BAR FRAME ---
 .faq-page-header-search {
-  margin-top: 50px;
+  max-width: 1000px; // Set this back to your exact Figma width
+  margin: 0 auto; // Centered horizontally
   display: grid;
-  grid-template-columns: 50px auto 50px;
-  //box-shadow: var(--shadow);
-  // border-image-source: var(--faq-pixel-border);
-  border-image-slice: 30;
-  border-image-width: 30px;
-  border-image-outset: 1px;
-  border-image-repeat: repeat;
-}
-
-.searchIcon {
-  height: 50px;
-  width: 50px;
-  color: var(--gray);
-  background-color: var(--faq-searchbar-bg);
-  display: grid;
-  place-items: center;
-  padding-left: 10px;
-  border-radius: 15px 0px 0px 15px;
-}
-
-.dragon-design {
-  margin: auto;
-  margin-top: -190px;
-  right: 5vw;
-  width: 300px;
-  position: absolute;
-  z-index: 1;
-}
-
-.searchIcon img {
-  height: 18px;
-  //opacity: 0.6;
-  transition: 200ms opacity;
-  cursor: url('../../assets/cursor/pointer.png'), auto;
-}
-
-.deleteIcon {
-  height: 50px;
-  width: 50px;
-  color: var(--gray);
-  background-color: var(--faq-searchbar-bg);
-  display: grid;
-  place-items: center;
-  padding-right: 10px;
-  border-radius: 0px 15px 15px 0px;
-}
-
-.deleteIcon:hover * {
-  cursor: url('../../assets/cursor/pointer.png'), auto;
-}
-
-.deleteIcon:hover {
-  img {
-    opacity: 1;
-    transition: 200ms opacity;
-  }
-}
-
-.deleteIcon img {
-  height: 25px;
-  opacity: 0.6;
-  transition: 200ms opacity;
+  grid-template-columns: 60px auto 60px;
+  border: 4px solid var(--mikado);
+  border-radius: 20px;
+  overflow: hidden;
+  position: relative;
+  z-index: 10;
+  background-color: var(--faq-bg-dark);
 }
 
 .faq-page-header-searchbar {
-  background-color: var(--faq-searchbar-bg);
-  border: 0;
-  border-radius: 0px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 0px;
-  font-size: 18px;
-  height: 50px;
   width: 100%;
-}
-
-.faq-search input:focus {
-  outline: none;
-}
-
-.faq-search-input {
-  margin-top: 2px;
+  height: 100%;
 }
 
 .faq-search-input-container {
-  background-color: var(--faq-searchbar-bg) !important;
-  cursor: url('../../assets/cursor/textpointer.png'), auto !important;
-}
-
-.faq-data-result {
-  width: calc(100% + 100px);
-  margin-left: -50px;
-  height: 200px;
-  background-color: var(--bg-primary);
-  box-shadow: var(--shadow) 0px 15px 15px;
-  overflow: hidden;
-  overflow-y: auto;
-  position: relative;
-  z-index: 2;
-  border-radius: 0px 0px 15px 15px;
-}
-
-.faq-data-result::-webkit-scrollbar {
-  display: none;
-}
-
-.faq-data-result .faq-data-item {
-  width: 100%;
-  height: 50px;
-  display: flex;
-  align-items: center;
-  color: var(--text-primary);
-}
-
-.faq-data-item p {
-  margin-left: 10px;
-}
-
-.faq-data-result div {
-  text-decoration: none;
-  transition: background-color 200ms, border-color 200ms;
-}
-
-.faq-data-item:hover {
-  cursor: url('../../assets/cursor/pointer.png'), auto !important;
-}
-
-.faq-data-result div:hover {
-  background-color: var(--bg-primary);
-  transition: background-color 200ms, border-color 200ms;
-}
-
-.faq-search-result-wrapper {
-  padding-left: 30px;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-}
-
-.faq-wave-image {
-  width: 100vw;
-  height: min(10vh, 80px);
-  object-fit: fill;
-  @include devices(tablet) {
-    height: min(10vh, 40px);
-  }
-}
-
-.faq-page-top-wave-image {
-  filter: drop-shadow(-10px 10px 8px #23232342);
-}
-
-.faq-accordion-container {
-  margin: 25px 0% 50px 0%;
-  background-color: var(--bg-primary);
-}
-
-.faq-accordion-wrapper {
-  margin: 15px 10% 20px 10%;
-
-  .accordion-clickable {
-    background-color: var(--faq-answer-containers);
-  }
-}
-
-.faq-accordion-wrapper:hover {
-  cursor: url('../../assets/cursor/pointer.png'), auto !important;
-}
-
-.faq-all-search-results {
-  color: var(--text-primary);
-  margin-top: -30px;
-  margin-bottom: 20px;
-}
-
-.faq-show-accordion {
-  display: block;
-}
-
-.faq-hide-accordion {
-  display: none;
-}
-
-.faq-search input {
-  background-color: white;
-  border: 0;
-  border-radius: 2px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 0px;
+  background-color: transparent !important;
+  border: none !important;
+  color: var(--text-white) !important;
+  font-family: 'Gliker', Impact, sans-serif;
   font-size: 18px;
-  padding: 15px;
-  height: 45px;
+  height: 54px;
   width: 100%;
+  padding: 0 10px;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: rgba(255, 211, 0, 0.4);
+  }
+
+  @include devices(tablet) {
+    font-size: 14px; // Makes the placeholder text smaller
+    height: 42px; // Shrinks the search bar height on mobile
+  }
 }
 
-.faq-search-results-hide {
-  display: none;
+.searchIcon,
+.deleteIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent !important;
+
+  img {
+    height: 20px;
+    width: 20px;
+  }
+}
+
+// --- TWO-COLUMN WORKSPACE WRAPPER ---
+.faq-content-row {
+  display: flex;
+  align-items: stretch; // Syncs heights so the left-side line matches the right-side box
+  gap: 30px; // Figma gap spacing
+  margin: 0px auto 80px auto; // Kept margin-top 0 so it slams flat under the search bar  padding: 0; // Stripped padding so boundaries snap perfectly to the search bar edge above
+  width: 100%;
+  max-width: 1000px; // MATCHES SEARCH BAR MAX-WIDTH EXACTLY
+  position: relative;
+  z-index: 5;
+  box-sizing: border-box;
+
+  @include devices(tablet) {
+    flex-direction: column;
+    gap: 40px;
+    padding: 0 5%;
+  }
+}
+
+// --- TIMELINE CONNECTING LINE SYSTEM ---
+.faq-button-selector-container {
+  flex: 0 0 280px; // Tightened space for sidebar text
+  width: 280px;
+  z-index: 6;
+  position: relative;
+  overflow: visible !important;
+  display: flex;
+  margin-top: 40px; // Matches info panel start exactly
+
+  .button-selector-items {
+    overflow: visible !important;
+    overflow-x: visible !important;
+    padding-left: 50px !important;
+    flex-direction: column !important;
+    width: 100%;
+    height: 100%;
+
+    @include devices(tablet) {
+      padding-left: 35px !important; // Pulls text closer to the timeline on mobile
+    }
+  }
+
+  @include devices(tablet) {
+    flex: none;
+    width: 100%;
+    margin-top: 0;
+  }
+}
+
+.faq-button-selector {
+  display: flex !important;
+  flex-direction: column !important;
+  justify-content: flex-start; // Changed from space-between to allow stable custom spacing
+  gap: 35px; // Keeps items evenly spaced downward
+  position: relative;
+  padding-left: 0;
+  padding-top: 0;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: visible !important;
+
+  @include devices(tablet) {
+    flex-direction: row !important;
+    flex-wrap: wrap;
+    gap: 15px;
+    height: auto;
+  }
+
+  // Visual Timeline Line Tracker
+  &::before {
+    content: '';
+    position: absolute;
+    left: 20px;
+    top: -5vh; // ALWAYS touches the top bar/start of the info panel
+    bottom: -6vh; // DYNAMICALLY adjusts perfectly with the end of the panel
+    width: 4px;
+    background-color: var(--mikado);
+
+    @include devices(tablet) {
+      display: block !important; // BRINGS THE LINE BACK ON MOBILE
+      left: 12px; // Positions it perfectly under the mobile stars axis
+      top: -5px;
+      bottom: -20px;
+    }
+  }
+}
+
+.faq-button-selector-btn {
+  // Strip all the pixel-border/shadow/sizing gunk from ButtonOutlined.scss
+  background-color: transparent !important;
+  background-image: none !important;
+  border-image-source: none !important;
+  border-image-slice: 0 !important;
+  border-image-width: 0 !important;
+  border-image-outset: 0 !important;
+  border-style: none !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  min-width: unset !important;
+  min-height: unset !important;
+  margin: 0 !important;
+  padding: 8px 15px !important;
+  width: 240px !important;
+  position: relative;
+  cursor: pointer;
+  justify-content: flex-start !important;
+
+  .text-container {
+    h1 {
+      font-family: 'Gliker', Impact, sans-serif !important;
+      font-size: 22px !important;
+      font-weight: 900 !important;
+      text-transform: uppercase;
+      color: var(--mikado) !important;
+      letter-spacing: 1px;
+      margin: 0;
+      text-align: left;
+
+      @include devices(tablet) {
+        font-size: 16px !important; // Shrinks category text names on mobile
+      }
+    }
+
+    h2 {
+      display: none; // hide "sub" text — Figma doesn't show a subtitle line
+    }
+  }
+
+  // The star — now targets a real, existing element, so it WILL render
+  &::before {
+    content: '★';
+    position: absolute;
+    left: -42px !important; // button sits at x=50 (from .button-selector-items padding-left:50px)
+    // so this places the star box's LEFT edge at x = 50-42 = 8
+    width: 28px; // star box is 28px wide -> its CENTER lands at x = 8+14 = 22
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--mikado);
+    font-size: 24px;
+    z-index: 10;
+    transition: transform 0.2s ease; // Smooth visual scaling on focus/hover transformations
+
+    @include devices(tablet) {
+      left: -32px !important; // Repositions the stars horizontally to sit exactly on the line
+      font-size: 18px; // Makes the stars slightly smaller for mobile
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  &:hover::before {
+    transform: translateY(-50%) scale(1.5); // Safely grows the star without shifting its horizontal positioning axis
+    //align-items: center;
+    //justify-content: center;
+    //left: -40px !important;
+  }
+
+  &:hover {
+    .text-container h1 {
+      //opacity: 0.8; // Dimming it slightly on hover makes it feel instantly interactive!
+      // Or you could do: color: var(--text-white) !important; if you want it to flash white!
+      transform: scale(
+        1.1
+      ); // Safely grows the star without shifting its horizontal positioning axis
+    }
+  }
+
+  // ACTIVE state: button-outlined WITHOUT the -secondary class
+  &:not(.button-outlined-secondary) {
+    background-color: var(--mikado) !important;
+    border-radius: 20px !important;
+    padding: 8px 20px !important;
+
+    .text-container h1 {
+      color: var(--faq-bg-dark) !important;
+    }
+  }
+
+  // INACTIVE state: has the -secondary class
+  &.button-outlined-secondary {
+    background-color: transparent !important;
+  }
+}
+
+// --- UNIFIED UNIBODY ACCORDION BLOCK FRAME ---
+.faq-accordion-container {
+  flex: 1; // Automatically claims all remaining horizontal width
+  width: 100%;
+  background-color: transparent !important;
+  border: 4px solid var(--mikado);
+  border-radius: 20px;
+  padding: 20px 40px; // Slightly reduced vertical padding inside the container
+  margin-top: 7vh;
+  box-sizing: border-box;
+  z-index: 6;
+
+  @include devices(tablet) {
+    padding: 12px 16px !important; // Drastically cuts down inner padding so text has room to breathe
+    margin-top: 15px !important; // Pulls it up closer to the category buttons
+    border-width: 4px !important; // Thins out the yellow border so it looks clean, not chunky
+    border-radius: 12px !important; // Gives it a tighter, cleaner corner radius for mobile
+  }
+}
+
+.faq-display-questions-container {
+  flex: 1;
+  width: 100%;
+  background-color: transparent !important;
+  border: 4px solid var(--mikado); // Ensures the golden container box stays visible on search!
+  border-radius: 20px;
+  padding: 20px 40px;
+  margin-top: 40px;
+  box-sizing: border-box;
+  z-index: 6;
+
+  @include devices(tablet) {
+    padding: 12px 16px !important; // Matches the exact same tight padding as the container above
+    margin-top: 10px !important; // Pulls the search result box up cleanly on mobile
+    border-width: 2px !important; // Thins out the border for search mode
+    border-radius: 12px !important; // Matches the corner radius
+  }
+
+  // Formatting for the "Search results..." heading block
+  .faq-all-search-results {
+    color: var(--text-white) !important;
+    font-family: 'Arial Black', Impact, sans-serif !important;
+    font-size: 18px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-top: 10px;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid rgba(255, 211, 0, 0.2);
+
+    @include devices(tablet) {
+      margin-bottom: 10px;
+    }
+  }
+
+  // Formatting for "No Results" notice box layout
+  .faq-no-results h1 {
+    color: var(--mikado) !important;
+    font-family: 'Arial Black', Impact, sans-serif !important;
+    font-size: 22px;
+    font-weight: 900;
+    text-align: center;
+    padding: 40px 0;
+  }
 }
 
 .faq-search-result-container {
-  margin: 15px 10px 0px 10px;
-  padding: 20px 30px 20px 30px;
-  background-color: var(--faq-answer-containers);
-  border-radius: 15px;
-  color: var(--sc-inverted) !important;
-}
+  padding: 12px 0px;
+  border-bottom: 1px solid rgba(255, 211, 0, 0.1); // Clean line break between multiple results
 
-.faq-search-result-question,
-.faq-search-result-question-accordion {
-  margin-bottom: 7px;
-  font-size: 22px;
-  font-weight: bold;
-  color: var(--sc-inverted) !important;
-  @include devices(tablet) {
-    font-size: 18px;
+  &:last-child {
+    border-bottom: none; // Disables trail line on the final search entry
   }
-}
 
-.faq-search-result-question-accordion {
-  padding: 20px 20px 20px 0px;
-  margin-bottom: 0px;
+  // Matches main question sizing exactly
+  .faq-search-result-question {
+    color: var(--mikado) !important;
+    font-family: 'Arial Black', Impact, sans-serif;
+    font-size: 22px;
+    font-weight: 900;
+    letter-spacing: 0.5px;
+    line-height: 1.3;
+    margin-bottom: 8px;
 
-  @include devices(tablet) {
-    padding: 15px 15px 15px 0px;
+    @include devices(tablet) {
+      font-size: 16px;
+    }
   }
-}
 
-.faq-search-result-answer,
-.faq-search-result-answer-accordion {
-  margin-top: 7px;
-  border-radius: 12px;
-  color: var(--lilac);
-  @include devices(tablet) {
+  // Matches main answer sizing exactly
+  .faq-search-result-answer {
+    color: var(--text-white) !important;
+    font-family: system-ui, -apple-system, sans-serif;
     font-size: 16px;
+    line-height: 1.6;
+    padding: 5px 0 10px 0;
+
+    @include devices(tablet) {
+      font-size: 13px;
+    }
+  }
+}
+
+// Stripping out all the individual box styling from the current build
+.faq-accordion-wrapper {
+  margin: 0;
+
+  // Target your inner accordion clickable headers
+  .accordion-clickable {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 12px 0px !important;
+
+    @include devices(tablet) {
+      padding: 5px 0px !important; // Shrinks vertical spacing between questions on mobile
+    }
+  }
+
+  div,
+  button {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+  }
+}
+
+.faq-search-result-question-accordion {
+  color: var(--mikado) !important;
+  font-family: 'Arial Black', Impact, sans-serif;
+  font-size: 22px; // Bumped up slightly to look bold and less squished
+  font-weight: 900;
+  letter-spacing: 0.5px;
+  line-height: 1.3; // Ensures multiple lines stack cleanly instead of squeezing
+
+  @include devices(tablet) {
+    font-size: 16px; // Shrinks accordion question title text on mobile
   }
 }
 
 .faq-search-result-answer-accordion {
-  padding: 0px 0px;
-  margin-left: 2px;
-  margin-top: -10px;
-  padding-bottom: 5px;
-}
+  color: var(--text-white) !important;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 16px;
+  padding: 5px 0 20px 0;
+  line-height: 1.6;
 
-.faq-no-results {
-  width: 100%;
-  text-align: center;
-  color: var(--text-primary);
-}
-
-.pagination-controls {
-  display: flex;
-  justify-content: center;
-  margin-top: 50px;
-
-  button {
-    margin: 0 5px;
-    padding: 10px 15px;
-    border: none;
-    border-radius: 5px;
-    background-color: var(--neutral-secondary);
-    color: var(--text-primary);
-    cursor: url('../../assets/cursor/pointer.png'), auto;
-    transition: background-color 0.3s, color 0.3s;
-
-    &:hover {
-      background-color: var(--neutral-secondary);
-      color: var(--text-primary);
-    }
-
-    &.active {
-      background-color: var(--monster);
-      color: var(--mikado);
-    }
+  @include devices(tablet) {
+    font-size: 13px; // Shrinks open answer text body on mobile
   }
+}
+
+// Utility hides
+.faq-hide-button-selector,
+.faq-hide-accordion {
+  display: none !important;
+}
+
+.faq-show-button-selector,
+.faq-show-accordion {
+  display: block !important;
+}
+
+.fill {
+  display: none;
 }

--- a/client/src/pages/FAQ/FAQ.scss
+++ b/client/src/pages/FAQ/FAQ.scss
@@ -1,17 +1,32 @@
 @import '../../scssStyles/mixins';
 
+// DEFAULT: Dark Mode Context
 :root {
-  --faq-bg-dark: #3d0f58; // Adjusted to match Figma's deep purple background
-  --faq-checker-purple: #460f64;
-  --mikado: #ffd300; // Figma Yellow
-  --text-white: #ffffff;
-  --checker-dark: #3d0f58;
-  --checker-light: #711f8b;
+  --faq-bg: #3d0f58;
+  --faq-checker: #711f8b;
+  --faq-text: #ffffff;
+  --faq-text-muted: rgba(255, 255, 255, 0.7);
+  --faq-accent: #ffc600; // Bold Gold
+  --faq-accent-hover: #fed34c; // Medium Gold
+  --faq-panel-bg: transparent;
+  --faq-search-placeholder: rgba(255, 198, 0, 0.4);
+}
+
+// LIGHT MODE OVERRIDES: Automatically maps when data-theme="light" is applied
+[data-theme='light'] {
+  --faq-bg: #ebebeb; // Light Gray
+  --faq-checker: #dfcdf3; // Soft Lavender
+  --faq-text: #3c3c3c; // Dark Charcoal Gray
+  --faq-text-muted: #711f8b; // Purple for sub-labels or descriptions
+  --faq-accent: #a77ad7; // Vibrant Blue for borders and interactive focal points
+  --faq-accent-hover: #ffc600; // Gold accent accents on select highlights
+  --faq-panel-bg: #ebebeb; // Crisp White for the card backgrounds so they lift off the gray
+  --faq-search-placeholder: #a77ad7;
 }
 
 // Outer page body wrapper context
 .bg-primary {
-  background-color: var(--faq-bg-dark) !important;
+  background-color: var(--faq-bg) !important;
   position: relative;
   width: 100%;
   min-height: 100vh;
@@ -30,17 +45,17 @@
     height: 200vh; // <-- changed from 125% to 125vh
     background-image: linear-gradient(
         45deg,
-        var(--checker-light) 25%,
+        var(--faq-checker) 25%,
         transparent 25%,
         transparent 75%,
-        var(--checker-light) 75%
+        var(--faq-checker) 75%
       ),
       linear-gradient(
         45deg,
-        var(--checker-light) 25%,
+        var(--faq-checker) 25%,
         transparent 25%,
         transparent 75%,
-        var(--checker-light) 75%
+        var(--faq-checker) 75%
       );
     background-size: 100px 100px;
     background-position: 0 0, 50px 50px;
@@ -69,17 +84,17 @@
     height: 150vh; // <-- changed from 150% to 150vh
     background-image: linear-gradient(
         45deg,
-        var(--checker-light) 25%,
+        var(--faq-checker) 25%,
         transparent 25%,
         transparent 75%,
-        var(--checker-light) 75%
+        var(--faq-checker) 75%
       ),
       linear-gradient(
         45deg,
-        var(--checker-light) 25%,
+        var(--faq-checker) 25%,
         transparent 25%,
         transparent 75%,
-        var(--checker-light) 75%
+        var(--faq-checker) 75%
       );
     background-size: 100px 100px;
     background-position: 0 0, 50px 50px;
@@ -124,7 +139,7 @@
   h1 {
     font-size: 120px;
     font-family: 'Gliker', Impact, sans-serif; // Swap with your exact Figma display font
-    color: var(--mikado);
+    color: var(--faq-accent);
     font-weight: 900;
     margin: 0 0 10px 0;
     text-transform: uppercase;
@@ -132,8 +147,7 @@
     letter-spacing: 5px;
 
     // The solid Neobrutalist block shadow from Figma
-    text-shadow: 3px 3px 3px #1e052d, 6px 6px 6px #1e052d, 9px 9px 6px #1e052d,
-      12px 12px 0px #1e052d;
+    text-shadow: 3px 3px 0px var(--faq-bg); // Keeps text readable against the checkers
 
     @include devices(tablet) {
       font-size: 54px; // Shrinks the giant FAQ title so it doesn't blow out mobile
@@ -153,12 +167,12 @@
   margin: 0 auto; // Centered horizontally
   display: grid;
   grid-template-columns: 60px auto 60px;
-  border: 4px solid var(--mikado);
+  border: 4px solid var(--faq-accent);
   border-radius: 20px;
   overflow: hidden;
   position: relative;
   z-index: 10;
-  background-color: var(--faq-bg-dark);
+  background-color: var(--faq-panel-bg);
 }
 
 .faq-page-header-searchbar {
@@ -169,7 +183,7 @@
 .faq-search-input-container {
   background-color: transparent !important;
   border: none !important;
-  color: var(--text-white) !important;
+  color: var(--faq-text) !important;
   font-family: 'Gliker', Impact, sans-serif;
   font-size: 18px;
   height: 54px;
@@ -181,7 +195,7 @@
   }
 
   &::placeholder {
-    color: rgba(255, 211, 0, 0.4);
+    color: var(--faq-search-placeholder);
   }
 
   @include devices(tablet) {
@@ -279,7 +293,7 @@
     top: -5vh; // ALWAYS touches the top bar/start of the info panel
     bottom: -6vh; // DYNAMICALLY adjusts perfectly with the end of the panel
     width: 4px;
-    background-color: var(--mikado);
+    background-color: var(--faq-accent); // Timeline tracker line
 
     @include devices(tablet) {
       display: block !important; // BRINGS THE LINE BACK ON MOBILE
@@ -316,7 +330,7 @@
       font-size: 22px !important;
       font-weight: 900 !important;
       text-transform: uppercase;
-      color: var(--mikado) !important;
+      color: var(--faq-accent) !important;
       letter-spacing: 1px;
       margin: 0;
       text-align: left;
@@ -344,7 +358,7 @@
     justify-content: center;
     top: 50%;
     transform: translateY(-50%);
-    color: var(--mikado);
+    color: var(--faq-accent); // Star icons
     font-size: 24px;
     z-index: 10;
     transition: transform 0.2s ease; // Smooth visual scaling on focus/hover transformations
@@ -376,12 +390,12 @@
 
   // ACTIVE state: button-outlined WITHOUT the -secondary class
   &:not(.button-outlined-secondary) {
-    background-color: var(--mikado) !important;
+    background-color: var(--faq-accent) !important;
     border-radius: 20px !important;
     padding: 8px 20px !important;
 
     .text-container h1 {
-      color: var(--faq-bg-dark) !important;
+      color: var(--faq-bg) !important; // Inverts text color inside active button block
     }
   }
 
@@ -395,8 +409,8 @@
 .faq-accordion-container {
   flex: 1; // Automatically claims all remaining horizontal width
   width: 100%;
-  background-color: transparent !important;
-  border: 4px solid var(--mikado);
+  background-color: var(--faq-panel-bg) !important;
+  border: 4px solid var(--faq-accent);
   border-radius: 20px;
   padding: 20px 40px; // Slightly reduced vertical padding inside the container
   margin-top: 7vh;
@@ -414,8 +428,8 @@
 .faq-display-questions-container {
   flex: 1;
   width: 100%;
-  background-color: transparent !important;
-  border: 4px solid var(--mikado); // Ensures the golden container box stays visible on search!
+  background-color: var(--faq-panel-bg) !important;
+  border: 4px solid var(--faq-accent);
   border-radius: 20px;
   padding: 20px 40px;
   margin-top: 40px;
@@ -467,8 +481,8 @@
 
   // Matches main question sizing exactly
   .faq-search-result-question {
-    color: var(--mikado) !important;
-    font-family: 'Arial Black', Impact, sans-serif;
+    color: var(--faq-accent) !important;
+    font-family: 'Gliker', Impact, sans-serif;
     font-size: 22px;
     font-weight: 900;
     letter-spacing: 0.5px;
@@ -482,7 +496,7 @@
 
   // Matches main answer sizing exactly
   .faq-search-result-answer {
-    color: var(--text-white) !important;
+    color: var(--faq-text) !important;
     font-family: system-ui, -apple-system, sans-serif;
     font-size: 16px;
     line-height: 1.6;
@@ -519,8 +533,8 @@
 }
 
 .faq-search-result-question-accordion {
-  color: var(--mikado) !important;
-  font-family: 'Arial Black', Impact, sans-serif;
+  color: var(--faq-accent) !important;
+  font-family: 'Gliker', Impact, sans-serif;
   font-size: 22px; // Bumped up slightly to look bold and less squished
   font-weight: 900;
   letter-spacing: 0.5px;
@@ -532,7 +546,7 @@
 }
 
 .faq-search-result-answer-accordion {
-  color: var(--text-white) !important;
+  color: var(--faq-text) !important;
   font-family: system-ui, -apple-system, sans-serif;
   font-size: 16px;
   padding: 5px 0 20px 0;


### PR DESCRIPTION
## Date:
June 24th, 2026

## Contribution:
- Fully redesigned the entire FAQ page interface, transforming the layout into a unified, clean, and modern user experience in adherence to the design on Figma.
- Added a dynamic, responsive "Add New Question" form panel for the FAQ section.
- Re-architected background asset coordinate structures to secure consistent responsive placement.

## Accomplishments:
- Separated the checkerboard background patterns into two distinct corner blocks, leaving the center solid purple so it doesn't crowd or overlap any text.
- Stripped out those clunky individual purple boxes around the category buttons and questions. Instead, I put the entire question section into a single, sleek transparent container with a gold border and clean dividing lines between rows.
- Built a front-end portal that lets Frosh add new questions
- Hooked up custom color variables to our theme context, making the entire page flip flawlessly between dark and light modes.

## Details:
- Split up the background shapes into separate `::before` and `::after` layers to give the layout room to breathe.
- Cleaned up the question list by replacing bulky borders with simple `border-bottom` divider lines.
- Aligned the new "Add Question" trigger button and panel with the exact 10% desktop padding margins of the search bar so the grid looks uniform.

## Complications: (Resolved)
- The background checkers were sliding around whenever I switched phone models during responsive testing. Fixed this by migrating horizontal percentages over to axis-locked vertical viewport units (vh).
- The new add-question form was slipping behind the background checkers at first. Resolved it by applying explicit relative positioning and a higher z-index to the module wrappers.

## Resources:
AI tools: Gemini